### PR TITLE
[HOTFIX] multiple fixes to merge queue

### DIFF
--- a/.github/actions/merge-queue-status/README.md
+++ b/.github/actions/merge-queue-status/README.md
@@ -46,6 +46,8 @@ Runs checks if either of :
 
 **Detection Method:** The action examines the most recent `synchronize` or `head_ref_force_pushed` event in the PR timeline. If this event was created by `github-merge-queue[bot]`, we know the merge queue just acted on the PR and checks should run. Otherwise, we check the status of the last workflow run.
 
+**Head Ref Format:** In merge queue events, the `head_ref` follows the format `refs/heads/gh-readonly-queue/main/pr-{number}-{sha}`, from which the PR number is extracted.
+
 ### Advanced Usage with Custom Parameters
 
 ```yaml

--- a/.github/actions/merge-queue-status/action.yml
+++ b/.github/actions/merge-queue-status/action.yml
@@ -34,123 +34,137 @@ runs:
       id: extract-pr-number
       shell: bash
       run: |
-        # Extract PR number from the head_ref (format: refs/pull/123/merge)
+        # Extract PR number from the merge queue head_ref
+        # Format: refs/heads/gh-readonly-queue/main/pr-123-<sha>
         MERGE_GROUP_EVENT='${{ inputs.merge-group-event }}'
         HEAD_REF=$(echo "$MERGE_GROUP_EVENT" | jq -r '.head_ref')
-        PR_NUMBER=$(echo "$HEAD_REF" | sed -n 's|^refs/pull/\([0-9]*\)/.*|\1|p')
+        PR_NUMBER=$(echo "$HEAD_REF" | sed -n 's|^refs/heads/gh-readonly-queue/.*/pr-\([0-9]*\)-.*|\1|p')
         echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
-    - name: Check merge queue conditions
-      id: check
+    - name: Extract last workflow run status
+      id: extract-workflow-status
       uses: actions/github-script@v7
       with:
         github-token: ${{ inputs.token }}
         script: |
           const prNumber = '${{ steps.extract-pr-number.outputs.pr_number }}';
-          const prWorkflowPath = '${{ inputs.pr-workflow-path }}';
           const checksJobName = '${{ inputs.checks-job-name }}';
 
-          if (!prNumber) {
-            return { shouldRun: true, reason: 'Unable to extract PR number' };
-          }
+          // Get PR details
+          const { data: pr } = await github.rest.pulls.get({
+            owner: 'scilus',
+            repo: 'nf-neuro',
+            pull_number: prNumber
+          });
 
-          try {
-            // Get PR details
-            const { data: pr } = await github.rest.pulls.get({
+          // Get all workflow runs associated to PR's branch, sorted by most recently created
+          const workflowRuns = await github.paginate(
+            github.rest.actions.listWorkflowRunsForRepo.endpoint.merge({
               owner: 'scilus',
               repo: 'nf-neuro',
-              pull_number: prNumber
-            });
+              event: 'pull_request',
+              branch: pr.head.ref,
+              per_page: 100
+            })
+          );
 
-            // Check if last event on the PR is synchronisation by the merge queue
-            const { data: events } = await github.rest.issues.listEventsForTimeline({
+          try {
+            const latestRun = workflowRuns[0];
+
+            // Get jobs for the latest workflow run
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun.endpoint.merge({
+                owner: 'scilus',
+                repo: 'nf-neuro',
+                run_id: latestRun.id,
+                per_page: 100
+              })
+            );
+
+            // Find the checks job by name and parse its status
+            const checksJob = jobs.find(job => job.name === checksJobName);
+
+            if (checksJob) {
+              checksJobStatus = checksJob.conclusion || checksJob.status;
+              hasFailedChecksJob = checksJob.conclusion === 'failure' ||
+                                  checksJob.conclusion === 'cancelled' ||
+                                  checksJob.conclusion === 'timed_out';
+
+              return { shouldRun: hasFailedChecksJob, reason: hasFailedChecksJob ? `${checksJobName} job ${checksJobStatus}` : 'Checks job passed' };
+            } else {
+              // Checks job supplied was not found in the latest run, so we should run checks
+              return { shouldRun: true, reason: `${checksJobName} job not found in latest run` };
+            }
+          } catch (error) {
+            // No workflow runs found, meaning we need to run checks
+            return { shouldRun: true, reason: 'No workflow runs found for PR' };
+          }
+
+    - name: Extract merge queue effect on PR
+      id: extract-merge-queue-effect
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const prNumber = '${{ steps.extract-pr-number.outputs.pr_number }}';
+
+          // Get all events associated to the PR, sorted by most recently created
+          const events = await github.paginate(
+            github.rest.issues.listEventsForTimeline.endpoint.merge({
               owner: 'scilus',
               repo: 'nf-neuro',
               issue_number: prNumber,
-              per_page: 50
-            });
-
-            const sortedEvents = events.sort(
-              (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-            );
-
-            const queueUpdatedPr = sortedEvents.length > 0 && (
-              sortedEvents[0].event === 'head_ref_force_pushed' ||
-              sortedEvents[0].event === 'synchronize'
-            ) && sortedEvents[0].actor.login === 'github-merge-queue[bot]';
-
-            // Check if the latest workflow run for the PR had a failed/cancelled checks job
-            const { data: workflowRuns } = await github.rest.actions.listWorkflowRunsForRepo({
-              owner: 'scilus',
-              repo: 'nf-neuro',
               per_page: 100
-            });
+            })
+          );
 
-            const relevantRuns = workflowRuns.workflow_runs.filter(run => {
-              return run.path === prWorkflowPath &&
-                    run.pull_requests &&
-                    run.pull_requests.some(pr => pr.number == prNumber);
-            }).sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+          try {
+            // Find last event that synchronized or force-pushed the PR
+            const lastSyncEvent = events.find(event => (
+              event.event === 'head_ref_force_pushed' ||
+              event.event === 'synchronize'
+            ))[0];
 
-            let hasFailedChecksJob = false;
-            let checksJobStatus = 'not_found';
-
-            if (relevantRuns.length > 0) {
-              const latestRun = relevantRuns[0];
-
-              const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
-                owner: 'scilus',
-                repo: 'nf-neuro',
-                run_id: latestRun.id
-              });
-
-              const checksJob = jobs.jobs.find(job => job.name === checksJobName);
-
-              if (checksJob) {
-                checksJobStatus = checksJob.conclusion || checksJob.status;
-                hasFailedChecksJob = checksJob.conclusion === 'failure' ||
-                                    checksJob.conclusion === 'cancelled' ||
-                                    checksJob.conclusion === 'timed_out';
-              } else {
-                hasFailedChecksJob = true;
-                checksJobStatus = 'not_found';
-              }
+            // If this last event is from the merge queue bot, we consider that the queue updated the PR
+            if (lastSyncEvent && lastSyncEvent.actor.login === 'github-merge-queue[bot]') {
+              return { shouldRun: true, reason: 'Most recent PR event was from merge queue bot' };
             } else {
-              hasFailedChecksJob = true;
+              return { shouldRun: false, reason: 'No recent merge queue activity' };
             }
-
-            const shouldRun = queueUpdatedPr || hasFailedChecksJob;
-
-            let reason = [];
-            if (queueUpdatedPr) {
-              reason.push('most recent PR event was from merge queue bot');
-            } else if (hasFailedChecksJob && checksJobStatus === 'not_found') {
-              reason.push(`${checksJobName} job not found in latest run of ${prWorkflowPath}`);
-            } else if (hasFailedChecksJob && checksJobStatus !== 'not_found') {
-              reason.push(`${checksJobName} job ${checksJobStatus} in latest run of ${prWorkflowPath}`);
-            } else {
-              reason.push(`${checksJobName} job passed and no recent merge queue activity`);
-            }
-
-            return {
-              shouldRun,
-              reason: reason.join(', ')
-            };
-
           } catch (error) {
-            return { shouldRun: true, reason: `API error: ${error}` };
+            // No events found, meaning we don't need to run checks here
+            return { shouldRun: false, reason: `No synchronisation or force push events found, no need to run checks` };
           }
 
     - name: Set outputs
       id: determine
       shell: bash
       run: |
-        RESULT='${{ steps.check.outputs.result }}'
-        SHOULD_RUN=$(echo "$RESULT" | jq -r '.shouldRun')
-        REASON=$(echo "$RESULT" | jq -r '.reason')
+        WORKFLOW_STATUS='${{ steps.extract-workflow-status.outputs.result }}'
+        MERGE_QUEUE_EFFECT='${{ steps.extract-merge-queue-effect.outputs.result }}'
 
+        # Extract shouldRun from both statuses
+        WORKFLOW_SHOULD_RUN=$(echo "$WORKFLOW_STATUS" | jq -r '.shouldRun')
+        MQ_SHOULD_RUN=$(echo "$MERGE_QUEUE_EFFECT" | jq -r '.shouldRun')
+        echo "Should run : Workflow=$WORKFLOW_SHOULD_RUN, Merge Queue=$MQ_SHOULD_RUN"
+        SHOULD_RUN=$([[ "$WORKFLOW_SHOULD_RUN" = "true" || "$MQ_SHOULD_RUN" = "true" ]] && echo "true" || echo "false")
         echo "should_run_checks=$SHOULD_RUN" >> $GITHUB_OUTPUT
-        echo "reason=$REASON" >> $GITHUB_OUTPUT
+
+        # Extract reason only if shouldRun is true for the specific status
+        REASON=()
+        if [ "$WORKFLOW_SHOULD_RUN" == "true" ]; then
+          REASON1=$(echo "$WORKFLOW_STATUS" | jq -r '.reason')
+          REASON+=("$REASON1")
+        fi
+        if [ "$MQ_SHOULD_RUN" == "true" ]; then
+          REASON2=$(echo "$MERGE_QUEUE_EFFECT" | jq -r '.reason')
+          REASON+=("$REASON2")
+        fi
+        REASON=$(IFS='; '; echo "${REASON[*]}")
+
+        echo "REASON: $REASON"
+        # Merge reasons from both checks
+        echo "reason=\"$REASON\"" >> $GITHUB_OUTPUT
 
         if [[ "$SHOULD_RUN" == "true" ]]; then
           echo "✅ Should run checks: $REASON"

--- a/.github/events/merge_group.json
+++ b/.github/events/merge_group.json
@@ -1,6 +1,6 @@
 {
     "merge_group": {
-        "head_ref": "refs/pull/123/merge",
+        "head_ref": "refs/heads/gh-readonly-queue/main/pr-189-abc123def456",
         "head_sha": "abc123def456",
         "base_sha": "def456ghi789",
         "base_ref": "refs/heads/main"

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -6,11 +6,6 @@ on:
     branches:
       - main
 
-# Cancel if a newer run is started
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   check-conditions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [x] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

Merge queue workflow not working as awaited. I've split the logic in steps for easier introspection.

The main problems :

- We aren't extracting the PR number correctly. The merge queue encodes the **head ref** in which we get that number differently
- Requests weren't paged correctly, so we skipped some results we needed
- No need to sort by date, the API returns results decrementing by date
