### PR TITLE
[HOTFIX] nf-test is not in PATH in the devcontainer anymore

### DIFF
--- a/.devcontainer/devops/onCreateCommand.sh
+++ b/.devcontainer/devops/onCreateCommand.sh
@@ -18,9 +18,6 @@ echo "export PATH=$PATH:/nf-test/bin" >> ~/.bashrc
 # Setup GitHub Actions testing environment
 echo "🎭 Setting up GitHub Actions testing tools..."
 
-# Add act and actionlint to PATH (already installed in Dockerfile)
-echo "export PATH=$PATH:/usr/local/bin" >> ~/.bashrc
-
 # Add GitHub Actions aliases to bashrc
 cat <<'EOF' >> ~/.bashrc
 


### PR DESCRIPTION
Removed redundant PATH export for act and actionlint.

## Bug category

- [ ] Critical (some functionalities is not working at all)
- [x] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

Update to the devcontainer's **bashrc** hid **nf-test** from the PATH.

## Steps to reproduce the bug

Provide a full step-by-step guide to reproduce the bug.
