### PR TITLE
FIX: File creation permission error on Amico-based processes.

### DIFF
--- a/modules/nf-neuro/reconst/noddi/main.nf
+++ b/modules/nf-neuro/reconst/noddi/main.nf
@@ -13,7 +13,7 @@ process RECONST_NODDI {
         tuple val(meta), path("*__fit_NDI.nii.gz")      , emit: ndi, optional: true
         tuple val(meta), path("*__fit_ECVF.nii.gz")     , emit: ecvf, optional: true
         tuple val(meta), path("*__fit_ODI.nii.gz")      , emit: odi, optional: true
-        tuple val(meta), path("kernels")                , emit: kernels, optional: true
+        path("kernels")                                 , emit: kernels, optional: true
         path "versions.yml"                             , emit: versions
 
     when:

--- a/modules/nf-neuro/reconst/noddi/meta.yml
+++ b/modules/nf-neuro/reconst/noddi/meta.yml
@@ -114,15 +114,10 @@ output:
           ontologies:
             - edam: http://edamontology.org/format_4001 # NIFTI format
   kernels:
-    - - meta:
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. `[ id:'test', single_end:false ]`
-      - kernels:
-          type: directory
-          description: Folder containing kernels.
-          pattern: kernels
+    - kernels:
+        type: directory
+        description: Folder containing kernels.
+        pattern: kernels
   versions:
     - versions.yml:
         type: file

--- a/modules/nf-neuro/reconst/noddi/tests/main.nf.test
+++ b/modules/nf-neuro/reconst/noddi/tests/main.nf.test
@@ -46,7 +46,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     process.out.versions,
-                    file(process.out.kernels.get(0).get(1)).listFiles().size()
+                    file(process.out.kernels.get(0)).listFiles().size()
                 ).match() }
             )
         }
@@ -80,7 +80,7 @@ nextflow_process {
                     file(process.out.ecvf.get(0).get(1)).name,
                     file(process.out.odi.get(0).get(1)).name,
                     process.out.versions,
-                    file(process.out.kernels.get(0).get(1)).listFiles().size()
+                    file(process.out.kernels.get(0)).listFiles().size()
                 ).match() }
             )
         }


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [x] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

The bug is described in the modifications.

## Steps to reproduce the bug

Run one of those two processes with the docker options '-u $(id -u):$(id -g)'.