### PR TITLE
FIX: Typo in `tractogram/removeinvalid`

### DIFF
--- a/modules/nf-neuro/tractogram/removeinvalid/main.nf
+++ b/modules/nf-neuro/tractogram/removeinvalid/main.nf
@@ -31,7 +31,7 @@ process TRACTOGRAM_REMOVEINVALID {
         ext=\${tractogram#*.}
         if [[ \$tractogram == *"__"* ]]; then
             pos=\$((\$(echo \$tractogram | grep -b -o __ | cut -d: -f1)+2))
-            bname=\$tractogram:\$pos
+            bname=\${tractogram:\$pos}
             bname=\$(basename \${bname} .\${ext})
         else
             bname=\$(basename \${tractogram} .\${ext} | sed 's/${prefix}_\\+//')
@@ -70,7 +70,7 @@ process TRACTOGRAM_REMOVEINVALID {
         ext=\${tractogram#*.}
         if [[ \$tractogram == *"__"* ]]; then
             pos=\$((\$(echo \$tractogram | grep -b -o __ | cut -d: -f1)+2))
-            bname=\$tractogram:\$pos
+            bname=\${tractogram:\$pos}
             bname=\$(basename \${bname} .\${ext})
         else
             bname=\$(basename \${tractogram} .\${ext} | sed 's/${prefix}_\\+//')


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [x] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

When I modified the module in my last PR, I made a typo in the way I extracted the `bname`. This fixes it.
