### PR TITLE
[HOTFIX] reassign runners to new naming

### DIFF
--- a/.github/workflows/run_checks_suite.yml
+++ b/.github/workflows/run_checks_suite.yml
@@ -191,14 +191,14 @@ jobs:
         path: ["${{ fromJson(needs.nf-test-changes.outputs.paths) }}"]
         include:
           - profile: docker
-          - runner: scilus-docker
-          - runner: scilus-docker-large
+          - runner: nf-neuro-docker
+          - runner: nf-neuro-docker-large
             path: modules/nf-neuro/registration/easyreg
-          - runner: scilus-docker-large
+          - runner: nf-neuro-docker-large
             path: modules/nf-neuro/segmentation/synthseg
-          - runner: scilus-docker-large
+          - runner: nf-neuro-docker-large
             path: modules/nf-neuro/betcrop/synthbet
-          - runner: scilus-docker-large
+          - runner: nf-neuro-docker-large
             path: modules/nf-neuro/registration/synthmorph
         exclude:
           - path: subworkflows/nf-neuro/load_test_data


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [ ] Major (something is not working as expected)
- [x] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

Ends up we cannot share `runner configuration` between **scilus** and **nf-neuro**, without either :
- Creating a **public Github App** for authentication, which anybody can join (bad !)
- Using **enterprise-level** features (and pay for them)

So, let's just **replicate runner configuration on both organisations**. For that however, we need to provide **unique names**. The reason why we need to adjust the names used here.
