### PR TITLE
Standardize meta mandatory key

### DIFF
--- a/docs/astro/templates/subworkflow.md.jinja2
+++ b/docs/astro/templates/subworkflow.md.jinja2
@@ -40,12 +40,12 @@ head:
 
 ### Outputs
 
-| | Type | Description | Optional | Pattern |
+| | Type | Description | Mandatory | Pattern |
 |-|-|-|-|-|
 
 {%- for channel in output %}
 {% for name, content in channel.items() -%}
-| {{ name }} | {{ content.type }} | {{ content.description | channel_descr }} | {{ content.optional | default(False) }} | {% if content.pattern %} `{{ content.pattern }}` {% endif %} |
+| {{ name }} | {{ content.type }} | {{ content.description | channel_descr }} | {{ content.mandatory | default(True) }} | {% if content.pattern %} `{{ content.pattern }}` {% endif %} |
 {%- endfor %}
 {%- endfor -%}
 {% endif %}

--- a/modules/nf-neuro/reconst/freewater/meta.yml
+++ b/modules/nf-neuro/reconst/freewater/meta.yml
@@ -56,19 +56,19 @@ input:
     - para_diff:
         type: float
         description: Parallel diffusivity value (diff prior).
-        optional: true
+        mandatory: false
     - iso_diff:
         type: float
         description: Isotropic diffusivity value (diff prior).
-        optional: true
+        mandatory: false
     - perp_diff_min:
         type: float
         description: Minimum perpendicular diffusivity value (diff prior).
-        optional: true
+        mandatory: false
     - perp_diff_max:
         type: float
         description: Maximum perpendicular diffusivity value (diff prior).
-        optional: true
+        mandatory: false
 output:
   dwi_fw_corrected:
     - - meta:

--- a/modules/nf-neuro/reconst/noddi/meta.yml
+++ b/modules/nf-neuro/reconst/noddi/meta.yml
@@ -55,11 +55,11 @@ input:
     - para_diff:
         type: float
         description: Parallel diffusivity value (diff prior).
-        optional: true
+        mandatory: false
     - iso_diff:
         type: float
         description: Isotropic diffusivity value (diff prior).
-        optional: true
+        mandatory: false
 
 output:
   dir:

--- a/modules/nf-neuro/registration/anattodwi/meta.yml
+++ b/modules/nf-neuro/registration/anattodwi/meta.yml
@@ -185,7 +185,7 @@ output:
             .gif file containing quality control image for the
             registration process. For use in MultiQC report.
           pattern: "*_registration_anattodwi_mqc.gif"
-          optional: true
+          mandatory: false
           ontologies: []
   versions:
     - versions.yml:

--- a/modules/nf-neuro/registration/ants/meta.yml
+++ b/modules/nf-neuro/registration/ants/meta.yml
@@ -171,7 +171,7 @@ output:
           type: file
           description: Affine transformation from moving to fixed
           pattern: "*_forward1_affine.mat"
-          optional: true
+          mandatory: false
           ontologies: []
   forward_warp:
     - - meta:
@@ -183,7 +183,7 @@ output:
           type: file
           description: Nifti volume containing warp field from moving to fixed
           pattern: "*_forward0_warp.nii.gz"
-          optional: true
+          mandatory: false
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
   backward_warp:
@@ -196,7 +196,7 @@ output:
           type: file
           description: Nifti volume containing warp field from fixed to moving
           pattern: "*_backward1_warp.nii.gz"
-          optional: true
+          mandatory: false
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
   backward_affine:
@@ -209,7 +209,7 @@ output:
           type: file
           description: Affine transformation from fixed to moving
           pattern: "*_backward0_affine.mat"
-          optional: true
+          mandatory: false
           ontologies: []
   forward_image_transform:
     - - meta:
@@ -274,7 +274,7 @@ output:
           description: .gif file containing quality control image for the registration
             process. Made for use in MultiQC report.
           pattern: "*_registration_ants_mqc.gif"
-          optional: true
+          mandatory: false
           ontologies: []
   versions:
     - versions.yml:

--- a/modules/nf-neuro/registration/antsapplytransforms/meta.yml
+++ b/modules/nf-neuro/registration/antsapplytransforms/meta.yml
@@ -144,7 +144,7 @@ output:
             .gif file containing quality control image for the registration process.
             Made for use in MultiQC report.
           pattern: "*_registration_antsapplytransforms_mqc.gif"
-          optional: true
+          mandatory: false
           ontologies: []
   versions:
     - versions.yml:

--- a/modules/nf-neuro/registration/easyreg/meta.yml
+++ b/modules/nf-neuro/registration/easyreg/meta.yml
@@ -93,7 +93,7 @@ output:
           type: file
           description: Forward deformation field, composed of all registration stages (affine+deformation).
           pattern: "*_forward0_warp.nii.gz"
-          optional: true
+          mandatory: false
           ontologies:
             - edam: http://edamontology.org/format_4001 # NIFTI format
   backward_warp:
@@ -106,7 +106,7 @@ output:
           type: file
           description: Backward deformation field, composed of all registration stages (inv-deformation+inv-affine).
           pattern: "*_backward0_warp.nii.gz"
-          optional: true
+          mandatory: false
           ontologies:
             - edam: http://edamontology.org/format_4001 # NIFTI format
   segmentation_warped:
@@ -121,7 +121,7 @@ output:
             SynthSeg v2 (non-robust) segmentation + parcellation on the warped image.
             Will produce image only if not passed as input.
           pattern: "*_warped_segmentation.nii.gz"
-          optional: true
+          mandatory: false
           ontologies:
             - edam: http://edamontology.org/format_4001 # NIFTI format
   fixed_segmentation_warped:
@@ -136,7 +136,7 @@ output:
             SynthSeg v2 (non-robust) segmentation + parcellation on the reference image.
             Will produce image only if not passed as input.
           pattern: "*_warped_reference_segmentation.nii.gz"
-          optional: true
+          mandatory: false
           ontologies:
             - edam: http://edamontology.org/format_4001 # NIFTI format
   versions:

--- a/modules/nf-neuro/registration/synthmorph/meta.yml
+++ b/modules/nf-neuro/registration/synthmorph/meta.yml
@@ -109,7 +109,7 @@ output:
           type: file
           description: Affine transformation matrix to fixed space.
           pattern: "*_forward{0,1,_standalone}_affine.lta"
-          optional: true
+          mandatory: false
           ontologies: []
   forward_warp:
     - - meta:
@@ -121,7 +121,7 @@ output:
           type: file
           description: Deformation field to fixed space.
           pattern: "*_forward0_deform.nii.gz"
-          optional: true
+          mandatory: false
           ontologies:
             - edam: http://edamontology.org/format_4001 # NIFTI format
   backward_warp:
@@ -134,7 +134,7 @@ output:
           type: file
           description: Deformation field to moving space.
           pattern: "*_backward1_deform.nii.gz"
-          optional: true
+          mandatory: false
           ontologies:
             - edam: http://edamontology.org/format_4001 # NIFTI format
   backward_affine:
@@ -147,7 +147,7 @@ output:
           type: file
           description: Affine transformation matrix to moving space.
           pattern: "*_backward{0,_standalone}_affine.lta"
-          optional: true
+          mandatory: false
           ontologies: []
   forward_image_transform:
     - - meta:

--- a/subworkflows/nf-neuro/bundle_seg/meta.yml
+++ b/subworkflows/nf-neuro/bundle_seg/meta.yml
@@ -82,7 +82,7 @@ output:
         Channel containing QC data for MultiQC reports.
         Structure: [ *mqc.* ]
       pattern: "*mqc.*"
-      optional: true
+      mandatory: false
   - versions:
       type: file
       description: |

--- a/subworkflows/nf-neuro/output_template_space/meta.yml
+++ b/subworkflows/nf-neuro/output_template_space/meta.yml
@@ -125,35 +125,35 @@ output:
         Channel containing the NIfTI files registered into the template space.
         Structure: [ val(meta), [path(nifti1), path(nifti2), path(nifti3), ...] ]
       pattern: "*.{nii,nii.gz}"
-      optional: true
+      mandatory: false
   - ch_registered_mask_files:
       type: file
       description: |
         Channel containing the mask files registered into the template space.
         Structure: [ val(meta), [path(mask1), path(mask2), path(mask3), ...] ]
       pattern: "*.{nii,nii.gz}"
-      optional: true
+      mandatory: false
   - ch_registered_labels_files:
       type: file
       description: |
         Channel containing the label files registered into the template space.
         Structure: [ val(meta), [path(label1), path(label2), path(label3), ...] ]
       pattern: "*.{nii,nii.gz}"
-      optional: true
+      mandatory: false
   - ch_registered_trk_files:
       type: file
       description: |
         Channel containing the TRK files registered into the template space.
         Structure: [ val(meta), [path(trk1), path(trk2), path(trk3), ...] ]
       pattern: "*.trk"
-      optional: true
+      mandatory: false
   - mqc:
       type: file
       description: |
         Channel containing the MultiQC report of the registration.
         Structure: [ path(mqc) ]
       pattern: "*mqc.*"
-      optional: true
+      mandatory: false
   - versions:
       type: file
       description: |

--- a/subworkflows/nf-neuro/reconst_fw_noddi/meta.yml
+++ b/subworkflows/nf-neuro/reconst_fw_noddi/meta.yml
@@ -83,35 +83,35 @@ output:
         Nifti file main direction.
         Structure: [ val(meta), path(dir) ]
       pattern: "*__fit_dir.nii.gz"
-      optional: true
+      mandatory: false
   - noddi_fwf:
       type: file
       description: |
         Nifti file for Free Water Fraction.
         Structure: [ val(meta), path(fwf) ]
       pattern: "*__fit_FWF.nii.gz"
-      optional: true
+      mandatory: false
   - noddi_ndi:
       type: file
       description: |
         Nifti file for Neurite Density Index.
         Structure: [ val(meta), path(ndi) ]
       pattern: "*__fit_NDI.nii.gz"
-      optional: true
+      mandatory: false
   - noddi_ecvf:
       type: file
       description: |
         Nifti file for Extra-Cellular Volume Fraction.
         Structure: [ val(meta), path(ecvf) ]
       pattern: "*__fit_ECVF.nii.gz"
-      optional: true
+      mandatory: false
   - noddi_odi:
       type: file
       description: |
         Nifti file for Orientation Dispersion Index.
         Structure: [ val(meta), path(odi) ]
       pattern: "*__fit_ODI.nii.gz"
-      optional: true
+      mandatory: false
   - versions:
       type: file
       description: |

--- a/subworkflows/nf-neuro/registration/meta.yml
+++ b/subworkflows/nf-neuro/registration/meta.yml
@@ -105,35 +105,35 @@ output:
         ONLY PROVIDED BY REGISTRATION_EASYREG. Channel containing the reference image warped in moving space.
         Structure: [ val(meta), path(image) ]
       pattern: "*.{nii,nii.gz}"
-      optional: true
+      mandatory: false
   - forward_affine:
       type: file
       description: |
         Channel containing the affine transformation matrix to fixed space.
         Structure: [ val(meta), path(forward_affine) ]
       pattern: "*__forward*.{lta,mat}"
-      optional: true
+      mandatory: false
   - forward_warp:
       type: file
       description: |
         Channel containing the deformation field to fixed space.
         Structure: [ val(meta), path(forward_warp) ]
       pattern: "*__forward*.{nii,nii.gz}"
-      optional: true
+      mandatory: false
   - backward_warp:
       type: file
       description: |
         Channel containing the deformation field to moving space.
         Structure: [ val(meta), path(backward_warp) ]
       pattern: "*__backward*.{nii,nii.gz}"
-      optional: true
+      mandatory: false
   - backward_affine:
       type: file
       description: |
         Channel containing the affine transformation matrix to moving space.
         Structure: [ val(meta), path(backward_affine) ]
       pattern: "*__backward*.{lta,mat}"
-      optional: true
+      mandatory: false
   - forward_image_transform:
       type: list
       description: |
@@ -169,7 +169,7 @@ output:
         segmentation + parcellation in moving space (floating in Easyreg naming convention).
         Structure: [ val(meta), path(segmentation) ]
       pattern: "*.{nii,nii.gz}"
-      optional: true
+      mandatory: false
   - reference_segmentation:
       type: file
       description: |
@@ -177,14 +177,14 @@ output:
         segmentation + parcellation in fixed space (reference in Easyreg naming convention).
         Structure: [ val(meta), path(reference_segmentation) ]
       pattern: "*.{nii,nii.gz}"
-      optional: true
+      mandatory: false
   - mqc:
       type: file
       description: |
         Channel containing the MultiQC report data for the registration.
         Structure: [ path(mqc) ]
       pattern: "*mqc.*"
-      optional: true
+      mandatory: false
   - versions:
       type: file
       description: |


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [x] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

While working on #175, I mixed `optional` and `mandatory` fields between input and output definitions in the `meta.yml`. The metadata was still valid (`optional: true` equals `mandatory: false`), but the conversion scripts don't support switching between the two conventions, so the information was missing from the API on the website.

## Describe the solution

I **chose `mandatory` as the standard key for both input and output, and dropped `optional` completely**. **Modules** were already configured as such, but not **Subworkflows**. While I know `optional` makes more sense when talking of outputs, having to switch when writing the `meta` error prone (I think I make a great example of it 😅). BTW, I have no opinion on this really, so if `optional` is preferable, I'll be happy to change. **I do think we need to keep only one though**.