### PR TITLE
FIX: Remove nested config

### DIFF
--- a/subworkflows/nf-neuro/atlas_iit/main.nf
+++ b/subworkflows/nf-neuro/atlas_iit/main.nf
@@ -110,8 +110,8 @@ workflow ATLAS_IIT {
 
     ch_versions = channel.empty()
 
-    def input_b0 = params.containsKey('atlas_iit') ? params.atlas_iit.b0 : null
-    def input_bundle_masks_dir = params.containsKey('atlas_iit') ? params.atlas_iit.bundle_masks_dir : null
+    def input_b0 = params.containsKey('atlas_iit_b0') ? params.atlas_iit_b0 : null
+    def input_bundle_masks_dir = params.containsKey('atlas_iit_bundle_masks_dir') ? params.atlas_iit_bundle_masks_dir : null
 
     // Fetch Mean B0
     if (input_b0) {

--- a/subworkflows/nf-neuro/atlas_iit/meta.yml
+++ b/subworkflows/nf-neuro/atlas_iit/meta.yml
@@ -24,7 +24,7 @@ keywords:
 components:
   - image/math
 args:
-  atlas_iit.b0:
+  atlas_iit_b0:
     type: string
     description: |
       Path to a Mean B0 map of the IIT Human Brain Atlas.
@@ -32,7 +32,7 @@ args:
       Structure: path(img)
     mandatory: false
     default: null
-  atlas_iit.bundle_masks_dir:
+  atlas_iit_bundle_masks_dir:
     type: string
     description: |
       Path to a directory containing IIT bundle masks.

--- a/subworkflows/nf-neuro/atlas_iit/nextflow.config
+++ b/subworkflows/nf-neuro/atlas_iit/nextflow.config
@@ -1,5 +1,5 @@
 process {
-    withName: 'THR_BUNDLE_MASK' {
+    withName: 'ATLAS_IIT:THR_BUNDLE_MASK' {
         ext.operation = 'lower_threshold'
         ext.suffix = 'mask'
     }


### PR DESCRIPTION
Apologies for the follow-up PR. In the previous atlas_iit subworkflow PR, I thought of nesting the parameters like the following: `atlas_iit.b0` and `atlas_iit.bundle_masks_dir`, but it looks like this is not supported by the nf-core pipelines schema tools. This PR is simply to revert to a flattened parameter configuration so that this can be integrated in the schema without warnings.

Having nested objects doesn’t seem to completely break the schema, but it causes issues when running `nf-core pipeline schema build`.

Also, doesn’t change much of anything, but I just precised the scope of the subworkflow default configuration.
