### PR TITLE
Fix containerOptions to be invoked only when using docker in multiqc

### DIFF
--- a/modules/nf-neuro/qc/multiqc/main.nf
+++ b/modules/nf-neuro/qc/multiqc/main.nf
@@ -4,7 +4,9 @@ process QC_MULTIQC {
 
     conda "${moduleDir}/environment.yml"
     container "gagnonanthony/multiqc-neuroimaging:latest"
-    containerOptions '--entrypoint "" -u $(id -u):$(id -g)'
+    containerOptions {
+        (workflow.containerEngine == 'docker') ? '--entrypoint "" --user $(id -u):$(id -g)' : ''
+    }
 
     input:
     tuple val(meta), path(qc_images)


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [x] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

Forgot to add this when I did the module, if we use singularity, will error out due to invalid argument.

## Steps to reproduce the bug

Provide a full step-by-step guide to reproduce the bug.
