### PR TITLE
FIX: GPU Local Tracking as non-root user 

### DIFF
--- a/modules/nf-neuro/tracking/localtracking/main.nf
+++ b/modules/nf-neuro/tracking/localtracking/main.nf
@@ -53,6 +53,13 @@ process TRACKING_LOCALTRACKING {
     }
 
     """
+    # Set home directory. This is problematic if the container is run
+    # with non-root user which does not create a home directory. When
+    # running the local tracking using GPU, its trying to write to
+    # ~/.cache/ directory, causing the job to fail.
+    mkdir -p /tmp
+    export HOME=/tmp
+
     export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=1
     export OMP_NUM_THREADS=1
     export OPENBLAS_NUM_THREADS=1


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [x] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

GPU tracking wasn't working when running the containers with the docker options `-u $(id -u):$(id -g)`. This PR fixes this issue. The error we had was the following:

<img width="1566" height="1235" alt="image" src="https://github.com/user-attachments/assets/18742ea0-024d-4dbf-a863-11d69c642f49" />

The solution implemented is exactly the one used in RECONST_NODDI and RECONST_FREEWATER.
