### PR TITLE
Replace run_pft with run_pft_tracking

### DIFF
--- a/subworkflows/nf-neuro/tractoflow/main.nf
+++ b/subworkflows/nf-neuro/tractoflow/main.nf
@@ -261,7 +261,7 @@ workflow TRACTOFLOW {
         // MODULE: Run TRACKING/PFTTRACKING
         //
         ch_pft_tracking = Channel.empty()
-        if ( params.run_pft ) {
+        if ( params.run_pft_tracking ) {
             ch_input_pft_tracking = ANATOMICAL_SEGMENTATION.out.wm_mask
                 .join(ANATOMICAL_SEGMENTATION.out.gm_mask)
                 .join(ANATOMICAL_SEGMENTATION.out.csf_mask)

--- a/subworkflows/nf-neuro/tractoflow/meta.yml
+++ b/subworkflows/nf-neuro/tractoflow/meta.yml
@@ -262,7 +262,7 @@ args:
       type: boolean
       description: Use Q-Ball model for tractography instead of fODFs.
       default: false
-  - run_pft:
+  - run_pft_tracking:
       type: boolean
       description: Enable Particle Filtering Tractography.
       default: true

--- a/subworkflows/nf-neuro/tractoflow/nextflow.config
+++ b/subworkflows/nf-neuro/tractoflow/nextflow.config
@@ -78,7 +78,7 @@ params {
     use_qball_for_tracking                          = false
 
     //**PFT tracking**//
-    run_pft                                         = true
+    run_pft_tracking                                = true
     pft_random_seed                                 = 0
     pft_algorithm                                   = "prob"
     pft_step_mm                                     = 0.5


### PR DESCRIPTION
It gets confusing as there's a parameter called `run_pft_tracking` in sf-tractomics that doesn't do much because this parameters is called `run_pft`. Imo, it makes more sense to name it in the same structure as `run_local_tracking`.