### PR TITLE
FIX: Bug when cleaning the stats.json

### DIFF
--- a/modules/nf-neuro/stats/metricsinroi/main.nf
+++ b/modules/nf-neuro/stats/metricsinroi/main.nf
@@ -73,8 +73,8 @@ process STATS_METRICSINROI {
             .value |= with_entries(
                 if (.key | test("_desc-[a-zA-Z0-9]+")) then
                     (.key | capture("_desc-(?<desc>[a-zA-Z0-9]+)").desc) as \$d |
-                    .value.extracted_desc = \$d |
-                    .key |= sub("_desc-[a-zA-Z0-9]+"; "")
+                    .key |= sub("_desc-[a-zA-Z0-9]+"; "") |
+                    .key |= if \$d == "fwc" then . + "t" else . + "_" + \$d end
                 else
                     .
                 end


### PR DESCRIPTION
When extracting the "desc" entity value, the previous implementation would overwrite the FA with the FA_fwc. This fixes it and also renames the key to `fat` instead of `fa_fwc` which follows the naming convention from the literature.