### PR TITLE
ENH: Update metric's name fetching to support new BIDS naming and freewater metrics

### DIFF
--- a/modules/nf-neuro/bundle/stats/main.nf
+++ b/modules/nf-neuro/bundle/stats/main.nf
@@ -237,10 +237,10 @@ process BUNDLE_STATS {
                             | sub("^" + \$sid + "__"; "")
                             | if test("param-") then
                                 (capture("param-(?<m>[^_]+)").m + (if test("desc-fwc") then "t" else "" end))
-                              elif test("_afd_metric\$") then "afd_fixel"
-                              elif test("desc-fwc") then
+                            elif test("_afd_metric\$") then "afd_fixel"
+                            elif test("desc-fwc") then
                                 (capture("__(?<m>[^.]+)").m + "t")
-                              else . end
+                            else . end
                         )
                     )
                 )
@@ -263,10 +263,10 @@ process BUNDLE_STATS {
                             | sub("^" + \$sid + "__"; "")
                             | if test("param-") then
                                 (capture("param-(?<m>[^_]+)").m + (if test("desc-fwc") then "t" else "" end))
-                              elif test("_afd_metric\$") then "afd_fixel"
-                              elif test("desc-fwc") then
+                            elif test("_afd_metric\$") then "afd_fixel"
+                            elif test("desc-fwc") then
                                 (capture("__(?<m>[^.]+)").m + "t")
-                              else . end
+                            else . end
                         )): .value.mean}
                     )
                     | add // {}
@@ -303,20 +303,20 @@ process BUNDLE_STATS {
                                 | sub("^" + \$sid + "__"; "")
                                 | if test("param-") then
                                     (capture("param-(?<m>[^_]+)").m + (if test("desc-fwc") then "t" else "" end))
-                                  elif test("_afd_metric\$") then "afd_fixel"
-                                  elif test("desc-fwc") then
+                                elif test("_afd_metric\$") then "afd_fixel"
+                                elif test("desc-fwc") then
                                     (capture("__(?<m>[^.]+)").m + "t")
-                                  else . end)
+                                else . end)
                         elif (.value | type == "object") then
                             # Per-point metric
                             (.key
                                 | sub("^" + \$sid + "__"; "")
                                 | if test("param-") then
                                     (capture("param-(?<m>[^_]+)").m + (if test("desc-fwc") then "t" else "" end))
-                                  elif test("_afd_metric\$") then "afd_fixel"
-                                  elif test("desc-fwc") then
+                                elif test("_afd_metric\$") then "afd_fixel"
+                                elif test("desc-fwc") then
                                     (capture("__(?<m>[^.]+)").m + "t")
-                                  else . end)
+                                else . end)
                         else empty end
                     )
                 )
@@ -358,10 +358,10 @@ process BUNDLE_STATS {
                             | sub("^" + \$sid + "__"; "")
                             | if test("param-") then
                                 (capture("param-(?<m>[^_]+)").m + (if test("desc-fwc") then "t" else "" end))
-                              elif test("_afd_metric\$") then "afd_fixel"
-                              elif test("desc-fwc") then
+                            elif test("_afd_metric\$") then "afd_fixel"
+                            elif test("desc-fwc") then
                                 (capture("__(?<m>[^.]+)").m + "t")
-                              else . end),
+                            else . end),
                         value: .value
                     })
                 ) as \$mes


### PR DESCRIPTION
## Type of improvement

**If submitting a new module or fixing a bug, please use the appropriate template.**

- [ ] Documentation
- [ ] Development tools (e.g. linter, formatter, etc.)
- [ ] Development container
- [ ] Global update (please specify)
- [x] Other (please specify)

## Describe your improvement

Similar to #278, this adds support for freewater-corrected DTI metrics by appending a "t". Also, I've updated the pattern from `desc-` to `param-` to match the recent BIDS convention.

## Describe how to test your improvement

Run the tests. 

## Checklist before requesting a review

- [x] Ensure the syntax is correct (**EditorConfig** and **Prettier** must pass)
- [x] Run the test suites if your changes affect any module
- [x] Regenerate the **Poetry** lock file if you have updated the dependencies
- [x] Ensure the documentation is up-to-date
