### PR TITLE
FIX: Synthstrip weights handling when none are supplied

### DIFF
--- a/subworkflows/nf-neuro/preproc_dwi/tests/main.nf.test
+++ b/subworkflows/nf-neuro/preproc_dwi/tests/main.nf.test
@@ -82,7 +82,7 @@ nextflow_workflow {
     }
 
     test("preproc_dwi - AP DWI | PA sbref") {
-
+        config "./nextflow_synthstrip.config"
         when {
             workflow {
                 """

--- a/subworkflows/nf-neuro/preproc_dwi/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/preproc_dwi/tests/main.nf.test.snap
@@ -159,7 +159,7 @@
                         {
                             "id": "test"
                         },
-                        "test__image_boundingBox.pkl"
+                        "test_dwi_cropped_bbox.pkl"
                     ]
                 ],
                 "mqc": [
@@ -189,14 +189,27 @@
                         "test__rev_dwi_eddy_mqc.gif"
                     ]
                 ],
+                "pwd_avg": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_pwd_avg.nii.gz"
+                    ]
+                ],
                 "versions": [
+                    "versions.yml:md5,00c3e8560e74fb87cacb736eb5658fcb",
                     "versions.yml:md5,034b6d262d1e0e45c673d3ac1756e22f",
                     "versions.yml:md5,218c08543fae3d1e7dd9b1527aa67a21",
-                    "versions.yml:md5,3efc92963bc72284def5a9aeff469919",
+                    "versions.yml:md5,2b1e0ce850286655d4510ff462e0f57b",
                     "versions.yml:md5,6775dffbd2264e526ccdfde32db655b9",
+                    "versions.yml:md5,73b36e0fa7fa782add714cca892bf09c",
+                    "versions.yml:md5,76b89b06b38b2148b5af5d388d333763",
                     "versions.yml:md5,a585ae0f02b31e59f3f641836f5cb608",
                     "versions.yml:md5,c6674ec69abd660014fba145790ec070",
                     "versions.yml:md5,c7da6834a9868efe7d6878ae023a6782",
+                    "versions.yml:md5,c9f89e6a31f3d2add46a0350e9ff799b",
+                    "versions.yml:md5,d1da6ec93d46e17eff56d0e7f9dc085d",
                     "versions.yml:md5,dd4515fa7d32a40e94927fddf215ef18",
                     "versions.yml:md5,fcf20744f2d2ea2b1a57d549d53c8ee6"
                 ]
@@ -204,9 +217,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.04.8"
         },
-        "timestamp": "2026-02-05T22:15:50.585412508"
+        "timestamp": "2026-02-11T13:35:27.137234"
     },
     "preproc_dwi - AP DWI | PA DWI": {
         "content": [


### PR DESCRIPTION
## Bug category

- [x] Critical (some functionalities is not working at all)
- [ ] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

Reported by @AntoineTheb when trying to run `sf-tractomics` with synthstrip.

```groovy
groovy.lang.MissingMethodException: No signature of method: Script_23251fc915320f64$_runScript_closure1$_closure2$_closure13.call() is applicable for argument types: (LinkedList) values: [[[id:sub-test_ses-low], /cubric/data/sapat10/work/9b/2444f6d8acb391eb2b48c8f67cad5e/sub-test_ses-low_pwd_avg.nii.gz]]
```

The use of `combine` with an empty channel creates issues when trying to unpack the items in the `map` call. I simply added a manual unpacking to handle cases where the weight item does not exist. I also added a test to make sure we don't miss this in the future.