### PR TITLE
Fix output path pattern in bundleparc

### DIFF
--- a/modules/nf-neuro/bundle/bundleparc/main.nf
+++ b/modules/nf-neuro/bundle/bundleparc/main.nf
@@ -8,7 +8,7 @@ process BUNDLE_BUNDLEPARC {
     tuple val(meta), path(fodf), path(checkpoint)
 
     output:
-    tuple val(meta), path("*__*_*.nii.gz"), emit: labels
+    tuple val(meta), path("*__*.nii.gz"), emit: labels
     path "versions.yml"              , emit: versions
 
     when:

--- a/modules/nf-neuro/bundle/bundleparc/meta.yml
+++ b/modules/nf-neuro/bundle/bundleparc/meta.yml
@@ -35,7 +35,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'test', single_end:false ]`
-      - "*__*_*.nii.gz":
+      - "*__*.nii.gz":
           type: file
           description: Label maps
           pattern: "*.nii.gz"


### PR DESCRIPTION
Not all bundles contain an underscore (CA, MCP)

## Filling your PR description

Click on the **preview tab** above to display the links to PR templates. Click on a template's link
to reopen this PR with the description pre-filled :

- [New module](?expand=1&template=new_module.md)
- [New subworkflow](?expand=1&template=new_subworkflow.md)
- [Bugfix](?expand=1&template=bugfix.md)
- [Improvement](?expand=1&template=improvement.md)
