### PR TITLE
[ENH] Add suffix to ants to prevent overwrite or some issues with stub-run

### DIFF
--- a/modules/nf-neuro/registration/ants/main.nf
+++ b/modules/nf-neuro/registration/ants/main.nf
@@ -138,6 +138,7 @@ process REGISTRATION_ANTS {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def suffix = task.ext.suffix ?: "warped"
     def suffix_qc = task.ext.suffix_qc ?: ""
     def run_qc = task.ext.run_qc as Boolean || false
 

--- a/modules/nf-neuro/registration/ants/main.nf
+++ b/modules/nf-neuro/registration/ants/main.nf
@@ -28,6 +28,7 @@ process REGISTRATION_ANTS {
     def initialization_types = ["geometric center": 0, "intensities": 1, "origin": 2]
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def suffix = task.ext.suffix ?: "warped"
     def suffix_qc = task.ext.suffix_qc ?: ""
     def ants = task.ext.quick ? "antsRegistrationSyNQuick.sh" : "antsRegistrationSyN.sh"
     def dimension = "-d ${task.ext.dimension ?: 3}"
@@ -61,7 +62,7 @@ process REGISTRATION_ANTS {
     moving_id=\${moving_base%.\${ext}}
     moving_id=\${moving_id#${prefix}_*}
 
-    mv outputWarped.nii.gz ${prefix}_\${moving_id}_warped.nii.gz
+    mv outputWarped.nii.gz ${prefix}_\${moving_id}_${suffix}.nii.gz
 
     if [ $transform != "bo" ] && [ $transform != "so" ]; then
         mv output0GenericAffine.mat ${prefix}_forward1_affine.mat
@@ -158,7 +159,7 @@ process REGISTRATION_ANTS {
     convert -help .
     scil_viz_volume_screenshot -h
 
-    touch ${prefix}_t1_warped.nii.gz
+    touch ${prefix}_t1_${suffix}.nii.gz
     touch ${prefix}_forward1_affine.mat
     touch ${prefix}_forward0_warp.nii.gz
     touch ${prefix}_backward1_warp.nii.gz

--- a/modules/nf-neuro/registration/ants/main.nf
+++ b/modules/nf-neuro/registration/ants/main.nf
@@ -160,7 +160,12 @@ process REGISTRATION_ANTS {
     convert -help .
     scil_viz_volume_screenshot -h
 
-    touch ${prefix}_t1_${suffix}.nii.gz
+    moving_base=\$(basename "${moving_image}")
+    ext=\${moving_base#*.}
+    moving_id=\${moving_base%.\${ext}}
+    moving_id=\${moving_id#${prefix}_*}
+
+    touch ${prefix}_\${moving_id}_${suffix}.nii.gz
     touch ${prefix}_forward1_affine.mat
     touch ${prefix}_forward0_warp.nii.gz
     touch ${prefix}_backward1_warp.nii.gz

--- a/modules/nf-neuro/registration/ants/meta.yml
+++ b/modules/nf-neuro/registration/ants/meta.yml
@@ -98,6 +98,12 @@ args:
       type: float
       description: "Distance between control points for B-spline SyN."
       default: 26
+  - suffix:
+      type: string
+      description: |
+        Obligatory suffix to add to the output file name to prevent overwrite
+        of input files. e.g. : the suffix `warped` will result in the name `image_warped.nii.gz`.
+      default: "warped"
   - run_qc:
       type: boolean
       description: "Run quality control (QC) to generate a MultiQC report."


### PR DESCRIPTION
When running two ants registration back to back stub-run fail because touch same files.

## Bug category

- [ ] Critical (some functionalities is not working at all)
- [ ] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

Write a clear and concise description of what the bug is.

## Steps to reproduce the bug

Provide a full step-by-step guide to reproduce the bug.
