### PR TITLE
Add stats/roivolumes module and GM volumes support in atlas_roimetrics

### DIFF
--- a/modules/nf-neuro/stats/metricsinroi/main.nf
+++ b/modules/nf-neuro/stats/metricsinroi/main.nf
@@ -53,7 +53,7 @@ process STATS_METRICSINROI {
 
         # scil_volume_stats_in_labels outputs metric-centric JSON {metric:{region:{mean,std}}}.
         # Transpose to region-centric {region:{metric:{mean,std}}} so the rest of the
-        # pipeline (key/value cleaning, header generation) works identically to WM mode.
+        # pipeline (key/value cleaning, header generation) works identically to labels mode.
         jq -r '
             [to_entries[] | .key as \$metric | .value | to_entries[] | {k: .key, mk: \$metric, v: .value}] |
             group_by(.k) |

--- a/modules/nf-neuro/stats/metricsinroi/main.nf
+++ b/modules/nf-neuro/stats/metricsinroi/main.nf
@@ -84,8 +84,7 @@ process STATS_METRICSINROI {
         with_entries(
             .key |= (
                 if test("^desc-[a-zA-Z0-9]+__") then
-                    capture("^desc-(?<d>[a-zA-Z0-9]+)__(?<rest>.+)$") |
-                    .rest + "_" + .d
+                    (split("__") | .[1] + "_" + (.[0] | ltrimstr("desc-")))
                 else
                     if startswith("_") then ltrimstr("_") else . end
                 end

--- a/modules/nf-neuro/stats/metricsinroi/main.nf
+++ b/modules/nf-neuro/stats/metricsinroi/main.nf
@@ -86,10 +86,8 @@ process STATS_METRICSINROI {
                 if test("^desc-[a-zA-Z0-9]+__") then
                     capture("^desc-(?<d>[a-zA-Z0-9]+)__(?<rest>.+)$") |
                     .rest + "_" + .d
-                elif startswith("_") then
-                    ltrimstr("_")
                 else
-                    .
+                    if startswith("_") then ltrimstr("_") else . end
                 end
             )
         )

--- a/modules/nf-neuro/stats/metricsinroi/main.nf
+++ b/modules/nf-neuro/stats/metricsinroi/main.nf
@@ -35,6 +35,7 @@ process STATS_METRICSINROI {
     def sep = output_format == 'tsv' ? '\t' : ','
     def subject_id_col = meta.id ?: ""
     def session_id_col = meta.session ?: ""
+    def run_id_col     = meta.run ?: ""
     """
     export OMP_NUM_THREADS=${task.ext.single_thread ? 1 : task.cpus}
 
@@ -124,9 +125,9 @@ process STATS_METRICSINROI {
     metrics=\$(FIRST_ROI="\$first_roi" jq -r ".\\"\$first_roi\\" | keys[]" ${prefix}_${suffix}.json)
 
     # Create the CSV/TSV headers
-    # (subject_id, session, roi, meta_columns..., metric1, metric2, ..., metricN)
-    header_mean="subject_id${sep}session${sep}roi"
-    header_std="subject_id${sep}session${sep}roi"
+    # (subject_id, session, run, roi, meta_columns..., metric1, metric2, ..., metricN)
+    header_mean="subject_id${sep}session${sep}run${sep}roi"
+    header_std="subject_id${sep}session${sep}run${sep}roi"
 
     # Create the meta columns
     for meta_col in ${meta_columns.join(' ')}; do
@@ -144,9 +145,9 @@ process STATS_METRICSINROI {
 
     for roi in \$rois;
     do
-        # Initialize lines with subject_id, session, and roi
-        line_mean="${subject_id_col}${sep}${session_id_col}${sep}\${roi}"
-        line_std="${subject_id_col}${sep}${session_id_col}${sep}\${roi}"
+        # Initialize lines with subject_id, session, run, and roi
+        line_mean="${subject_id_col}${sep}${session_id_col}${sep}${run_id_col}${sep}\${roi}"
+        line_std="${subject_id_col}${sep}${session_id_col}${sep}${run_id_col}${sep}\${roi}"
 
         # Add meta columns values if specified
         for meta_val in ${meta_columns_values.join(' ')}; do

--- a/modules/nf-neuro/stats/metricsinroi/main.nf
+++ b/modules/nf-neuro/stats/metricsinroi/main.nf
@@ -43,7 +43,8 @@ process STATS_METRICSINROI {
     then
         if [[ ! -f "$rois_lut" ]];
         then
-            echo "ROI LUT is missing. Will fail."
+            echo "ROI LUT is missing. Aborting." >&2
+            exit 1
         fi
 
         scil_volume_stats_in_labels $rois $rois_lut \
@@ -140,15 +141,15 @@ process STATS_METRICSINROI {
     ' ${prefix}_${suffix}.json > ${prefix}_${suffix}_tmp.json
     mv ${prefix}_${suffix}_tmp.json ${prefix}_${suffix}.json
 
-    # Get all ROIs names from the JSON
-    rois=\$(jq -r "keys[]" ${prefix}_${suffix}.json)
+    # Get all ROI names from the JSON (renamed to avoid shadowing the input path variable)
+    roi_names=\$(jq -r "keys[]" ${prefix}_${suffix}.json)
 
-    # All ROIs have the same metrics. To get the metrics names from
+    # All ROIs have the same metrics. To get the metric names from
     # the JSON, we can just fetch them from the first ROI.
-    first_roi=\$(printf '%s\\n' \$rois | head -n 1)
+    first_roi=\$(printf '%s\\n' \$roi_names | head -n 1)
 
-    # Extract the metrics names from this first roi
-    metrics=\$(FIRST_ROI="\$first_roi" jq -r ".\\"\$first_roi\\" | keys[]" ${prefix}_${suffix}.json)
+    # Extract the metric names from this first roi (renamed to avoid shadowing the input path variable)
+    metric_names=\$(FIRST_ROI="\$first_roi" jq -r ".\\"\$first_roi\\" | keys[]" ${prefix}_${suffix}.json)
 
     # Create the CSV/TSV headers
     # (subject_id, session, run, roi, meta_columns..., metric1, metric2, ..., metricN)
@@ -162,14 +163,14 @@ process STATS_METRICSINROI {
     done
 
     # Add the metric columns
-    for metric in \$metrics; do
+    for metric in \$metric_names; do
         header_mean="\${header_mean}${sep}\${metric}"
         header_std="\${header_std}${sep}\${metric}"
     done
     echo "\$header_mean" > ${prefix}_desc-mean_${suffix}.${output_format}
     echo "\$header_std" > ${prefix}_desc-std_${suffix}.${output_format}
 
-    for roi in \$rois;
+    for roi in \$roi_names;
     do
         # Initialize lines with subject_id, session, run, and roi
         line_mean="${subject_id_col}${sep}${session_id_col}${sep}${run_id_col}${sep}\${roi}"
@@ -186,7 +187,7 @@ process STATS_METRICSINROI {
             fi
         done
 
-        for metric in \$metrics;
+        for metric in \$metric_names;
         do
             # Fetch the "mean" and "std" values from each roi/metric
             # pair from the JSON

--- a/modules/nf-neuro/stats/metricsinroi/main.nf
+++ b/modules/nf-neuro/stats/metricsinroi/main.nf
@@ -33,6 +33,8 @@ process STATS_METRICSINROI {
     assert output_format in ['csv', 'tsv'] : "output_format must be either 'csv' or 'tsv'"
 
     def sep = output_format == 'tsv' ? '\t' : ','
+    def subject_id_col = meta.id ?: ""
+    def session_id_col = meta.session ?: ""
     """
     export OMP_NUM_THREADS=${task.ext.single_thread ? 1 : task.cpus}
 
@@ -122,9 +124,9 @@ process STATS_METRICSINROI {
     metrics=\$(FIRST_ROI="\$first_roi" jq -r ".\\"\$first_roi\\" | keys[]" ${prefix}_${suffix}.json)
 
     # Create the CSV/TSV headers
-    # (sample, roi, metric1, metric2, ..., metricN)
-    header_mean="sample${sep}roi"
-    header_std="sample${sep}roi"
+    # (subject_id, session, roi, meta_columns..., metric1, metric2, ..., metricN)
+    header_mean="subject_id${sep}session${sep}roi"
+    header_std="subject_id${sep}session${sep}roi"
 
     # Create the meta columns
     for meta_col in ${meta_columns.join(' ')}; do
@@ -142,9 +144,9 @@ process STATS_METRICSINROI {
 
     for roi in \$rois;
     do
-        # Initialize lines with sample and roi
-        line_mean="${prefix}${sep}\${roi}"
-        line_std="${prefix}${sep}\${roi}"
+        # Initialize lines with subject_id, session, and roi
+        line_mean="${subject_id_col}${sep}${session_id_col}${sep}\${roi}"
+        line_std="${subject_id_col}${sep}${session_id_col}${sep}\${roi}"
 
         # Add meta columns values if specified
         for meta_val in ${meta_columns_values.join(' ')}; do

--- a/modules/nf-neuro/stats/metricsinroi/main.nf
+++ b/modules/nf-neuro/stats/metricsinroi/main.nf
@@ -49,6 +49,17 @@ process STATS_METRICSINROI {
         scil_volume_stats_in_labels $rois $rois_lut \
             --metrics $metrics \
             --sort_keys > ${prefix}_${suffix}.json
+
+        # scil_volume_stats_in_labels outputs metric-centric JSON {metric:{region:{mean,std}}}.
+        # Transpose to region-centric {region:{metric:{mean,std}}} so the rest of the
+        # pipeline (key/value cleaning, header generation) works identically to WM mode.
+        jq -r '
+            [to_entries[] | .key as \$metric | .value | to_entries[] | {k: .key, mk: \$metric, v: .value}] |
+            group_by(.k) |
+            map({key: .[0].k, value: (map({key: .mk, value: .v}) | from_entries)}) |
+            from_entries
+        ' ${prefix}_${suffix}.json > ${prefix}_${suffix}_tmp.json
+        mv ${prefix}_${suffix}_tmp.json ${prefix}_${suffix}.json
     else
         scil_volume_stats_in_ROI $rois \
             --metrics $metrics \
@@ -66,6 +77,24 @@ process STATS_METRICSINROI {
         ' ${prefix}_${suffix}.json > ${prefix}_${suffix}_tmp.json
         mv ${prefix}_${suffix}_tmp.json ${prefix}_${suffix}.json
     done
+
+    # Normalize outer keys: strip leading '_' (artifact of double-__ file naming convention
+    # after prefix removal) and convert 'desc-xxx__metric' to 'metric_xxx'.
+    jq -r '
+        with_entries(
+            .key |= (
+                if test("^desc-[a-zA-Z0-9]+__") then
+                    capture("^desc-(?<d>[a-zA-Z0-9]+)__(?<rest>.+)$") |
+                    .rest + "_" + .d
+                elif startswith("_") then
+                    ltrimstr("_")
+                else
+                    .
+                end
+            )
+        )
+    ' ${prefix}_${suffix}.json > ${prefix}_${suffix}_tmp.json
+    mv ${prefix}_${suffix}_tmp.json ${prefix}_${suffix}.json
 
     # Extract 'desc' substring from keys and store it temporarily in values
     # This allows us to remove the substring from the key now and append it later
@@ -126,8 +155,8 @@ process STATS_METRICSINROI {
 
     # Create the CSV/TSV headers
     # (subject_id, session, run, roi, meta_columns..., metric1, metric2, ..., metricN)
-    header_mean="subject_id${sep}session${sep}run${sep}roi"
-    header_std="subject_id${sep}session${sep}run${sep}roi"
+    header_mean="sid${sep}session${sep}run${sep}roi"
+    header_std="sid${sep}session${sep}run${sep}roi"
 
     # Create the meta columns
     for meta_col in ${meta_columns.join(' ')}; do

--- a/modules/nf-neuro/stats/roivolumes/environment.yml
+++ b/modules/nf-neuro/stats/roivolumes/environment.yml
@@ -1,0 +1,3 @@
+channels: []
+dependencies: []
+name: stats_roivolumes

--- a/modules/nf-neuro/stats/roivolumes/environment.yml
+++ b/modules/nf-neuro/stats/roivolumes/environment.yml
@@ -1,3 +1,7 @@
-channels: []
-dependencies: []
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - nibabel>=4.0.0
+  - numpy>=1.24.0
 name: stats_roivolumes

--- a/modules/nf-neuro/stats/roivolumes/environment.yml
+++ b/modules/nf-neuro/stats/roivolumes/environment.yml
@@ -2,5 +2,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - nibabel>=4.0.0
-  - numpy>=1.24.0
+  - nibabel=4.0.0
+  - numpy=1.24.0

--- a/modules/nf-neuro/stats/roivolumes/environment.yml
+++ b/modules/nf-neuro/stats/roivolumes/environment.yml
@@ -4,4 +4,3 @@ channels:
 dependencies:
   - nibabel>=4.0.0
   - numpy>=1.24.0
-name: stats_roivolumes

--- a/modules/nf-neuro/stats/roivolumes/main.nf
+++ b/modules/nf-neuro/stats/roivolumes/main.nf
@@ -79,9 +79,6 @@ else:
                     break
             for s in substrs:
                 bundle = bundle.removeprefix(s).removesuffix(s)
-            # Strip the session prefix after subject prefix is already removed
-            if session_id and bundle.startswith(session_id + "_"):
-                bundle = bundle[len(session_id) + 1:]
 
             img     = nib.load(mask_file)
             data    = img.get_fdata()

--- a/modules/nf-neuro/stats/roivolumes/main.nf
+++ b/modules/nf-neuro/stats/roivolumes/main.nf
@@ -57,7 +57,7 @@ if use_label:
         lut = json.load(f)
 
     with open(output_file, 'w') as out:
-        out.write("subject_id,session,run,region,volume_voxels,volume_mm3\\n")
+        out.write("sid,session,run,region,volume_voxels,volume_mm3\\n")
         for label_id, label_name in sorted(lut.items(), key=lambda x: int(x[0])):
             count   = int(np.sum(data_int == int(label_id)))
             vol_mm3 = count * vox_vol
@@ -70,18 +70,18 @@ else:
     mask_files = sorted("${rois_str}".split())
 
     with open(output_file, 'w') as out:
-        out.write("subject_id,session,run,bundle,volume_voxels,volume_mm3\\n")
+        out.write("sid,session,run,bundle,volume_voxels,volume_mm3\\n")
         for mask_file in mask_files:
             bundle = os.path.basename(mask_file)
             for ext in ('.nii.gz', '.nii'):
                 if bundle.endswith(ext):
                     bundle = bundle[:-len(ext)]
                     break
-            # Strip the session prefix that ANTSAPPLYTRANSFORMS adds to output filenames
-            if session_id and bundle.startswith(session_id + "_"):
-                bundle = bundle[len(session_id) + 1:]
             for s in substrs:
                 bundle = bundle.removeprefix(s).removesuffix(s)
+            # Strip the session prefix after subject prefix is already removed
+            if session_id and bundle.startswith(session_id + "_"):
+                bundle = bundle[len(session_id) + 1:]
 
             img     = nib.load(mask_file)
             data    = img.get_fdata()

--- a/modules/nf-neuro/stats/roivolumes/main.nf
+++ b/modules/nf-neuro/stats/roivolumes/main.nf
@@ -2,7 +2,7 @@ process STATS_ROIVOLUMES {
     tag "$meta.id"
     label 'process_single'
 
-    container "scilus/scilpy:2.2.2_cpu"
+    container "docker.io/scilus/scilpy:2.2.2_cpu"
 
     input:
     tuple val(meta), path(rois), path(rois_lut)  /* optional, input = [] */

--- a/modules/nf-neuro/stats/roivolumes/main.nf
+++ b/modules/nf-neuro/stats/roivolumes/main.nf
@@ -58,7 +58,7 @@ if use_label:
         lut = json.load(f)
 
     with open(output_file, 'w') as out:
-        out.write("sid,session,run,region,volume_voxels,volume_mm3\\n")
+        out.write("sid,session,run,roi,volume_voxels,volume_mm3\\n")
         for label_id, label_name in sorted(lut.items(), key=lambda x: int(x[0])):
             count   = int(np.sum(data_int == int(label_id)))
             vol_mm3 = count * vox_vol
@@ -71,22 +71,22 @@ else:
     mask_files = sorted("${rois_str}".split())
 
     with open(output_file, 'w') as out:
-        out.write("sid,session,run,bundle,volume_voxels,volume_mm3\\n")
+        out.write("sid,session,run,roi,volume_voxels,volume_mm3\\n")
         for mask_file in mask_files:
-            bundle = os.path.basename(mask_file)
+            roi_name = os.path.basename(mask_file)
             for ext in ('.nii.gz', '.nii'):
-                if bundle.endswith(ext):
-                    bundle = bundle[:-len(ext)]
+                if roi_name.endswith(ext):
+                    roi_name = roi_name[:-len(ext)]
                     break
             for s in substrs:
-                bundle = bundle.removeprefix(s).removesuffix(s)
+                roi_name = roi_name.removeprefix(s).removesuffix(s)
 
             img     = nib.load(mask_file)
             data    = img.get_fdata()
             vox_vol = float(np.prod(img.header.get_zooms()[:3]))
             count   = int(np.sum(data > 0))
             vol_mm3 = count * vox_vol
-            out.write(f"{subject_id},{session_id},{run_id},{bundle},{count},{vol_mm3:.4f}\\n")
+            out.write(f"{subject_id},{session_id},{run_id},{roi_name},{count},{vol_mm3:.4f}\\n")
 
 with open("versions.yml", "w") as v:
     v.write('"${task.process}":\\n')

--- a/modules/nf-neuro/stats/roivolumes/main.nf
+++ b/modules/nf-neuro/stats/roivolumes/main.nf
@@ -1,0 +1,104 @@
+process STATS_ROIVOLUMES {
+    tag "$meta.id"
+    label 'process_single'
+
+    container "scilus/scilpy:2.2.2_cpu"
+
+    input:
+    tuple val(meta), path(rois), path(rois_lut)  /* optional, input = [] */
+
+    output:
+    tuple val(meta), path("*_volumes.csv"), emit: volumes
+    path "versions.yml",                    emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def prefix            = task.ext.prefix ?: "${meta.id}"
+    def suffix            = task.ext.first_suffix ? "${task.ext.first_suffix}_volumes" : "volumes"
+    def use_label         = task.ext.use_label ? true : false
+    def use_label_py      = use_label ? "True" : "False"
+    def substrs_to_remove = task.ext.key_substrs_to_remove ?: []
+    def substrs_json      = groovy.json.JsonOutput.toJson(substrs_to_remove)
+    // For WM mode: rois is a list; join paths as space-separated string for Python to split
+    def rois_str          = rois instanceof List ? rois.join(' ') : "${rois}"
+    """
+    python3 << 'PYEOF'
+import nibabel as nib
+import numpy as np
+import json
+import os
+
+prefix    = "${prefix}"
+suffix    = "${suffix}"
+use_label = ${use_label_py}
+substrs   = ${substrs_json}
+
+output_file = f"{prefix}_{suffix}.csv"
+
+if use_label:
+    # GM mode: single label atlas — load once, count all labels in one pass.
+    # Equivalent per label to:
+    #   mrcalc atlas <label_id> -eq mask + mrstats mask -mask mask -output count
+    img  = nib.load("${rois}")
+    data = img.get_fdata()
+    # Round to nearest integer to guard against MultiLabel warp float precision
+    data_int = np.round(data).astype(np.int32)
+    vox_vol  = float(np.prod(img.header.get_zooms()[:3]))
+
+    with open("${rois_lut}") as f:
+        lut = json.load(f)
+
+    with open(output_file, 'w') as out:
+        out.write("subject_id,region,volume_voxels,volume_mm3\\n")
+        for label_id, label_name in sorted(lut.items(), key=lambda x: int(x[0])):
+            count   = int(np.sum(data_int == int(label_id)))
+            vol_mm3 = count * vox_vol
+            out.write(f"{prefix},{label_name},{count},{vol_mm3:.4f}\\n")
+else:
+    # WM mode: list of binary/TDI masks.
+    # Equivalent per mask to:
+    #   mrstats mask -mask mask -output count
+    # np.sum(data > 0) counts finite non-zero voxels (NaN > 0 == False, excluded).
+    mask_files = sorted("${rois_str}".split())
+
+    with open(output_file, 'w') as out:
+        out.write("subject_id,region,volume_voxels,volume_mm3\\n")
+        for mask_file in mask_files:
+            region = os.path.basename(mask_file)
+            for ext in ('.nii.gz', '.nii'):
+                if region.endswith(ext):
+                    region = region[:-len(ext)]
+                    break
+            for s in substrs:
+                region = region.removeprefix(s).removesuffix(s)
+
+            img     = nib.load(mask_file)
+            data    = img.get_fdata()
+            vox_vol = float(np.prod(img.header.get_zooms()[:3]))
+            count   = int(np.sum(data > 0))
+            vol_mm3 = count * vox_vol
+            out.write(f"{prefix},{region},{count},{vol_mm3:.4f}\\n")
+PYEOF
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        nibabel: \$(python3 -c "import nibabel; print(nibabel.__version__)")
+        numpy: \$(python3 -c "import numpy; print(numpy.__version__)")
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def suffix = task.ext.first_suffix ? "${task.ext.first_suffix}_volumes" : "volumes"
+    """
+    touch ${prefix}_${suffix}.csv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        nibabel: \$(python3 -c "import nibabel; print(nibabel.__version__)")
+        numpy: \$(python3 -c "import numpy; print(numpy.__version__)")
+    END_VERSIONS
+    """
+}

--- a/modules/nf-neuro/stats/roivolumes/main.nf
+++ b/modules/nf-neuro/stats/roivolumes/main.nf
@@ -9,7 +9,7 @@ process STATS_ROIVOLUMES {
 
     output:
     tuple val(meta), path("*_volumes.csv"), emit: volumes
-    path "versions.yml",                    emit: versions
+    path "versions.yml",                    emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-neuro/stats/roivolumes/main.nf
+++ b/modules/nf-neuro/stats/roivolumes/main.nf
@@ -23,6 +23,8 @@ process STATS_ROIVOLUMES {
     def substrs_json      = groovy.json.JsonOutput.toJson(substrs_to_remove)
     // For WM mode: rois is a list; join paths as space-separated string for Python to split
     def rois_str          = rois instanceof List ? rois.join(' ') : "${rois}"
+    def subject_id        = meta.id ?: ""
+    def session_id        = meta.session ?: ""
     """
     python3 << 'PYEOF'
 import nibabel as nib
@@ -30,10 +32,12 @@ import numpy as np
 import json
 import os
 
-prefix    = "${prefix}"
-suffix    = "${suffix}"
-use_label = ${use_label_py}
-substrs   = ${substrs_json}
+prefix     = "${prefix}"
+suffix     = "${suffix}"
+use_label  = ${use_label_py}
+substrs    = ${substrs_json}
+subject_id = "${subject_id}"
+session_id = "${session_id}"
 
 output_file = f"{prefix}_{suffix}.csv"
 
@@ -51,11 +55,11 @@ if use_label:
         lut = json.load(f)
 
     with open(output_file, 'w') as out:
-        out.write("subject_id,region,volume_voxels,volume_mm3\\n")
+        out.write("subject_id,session,region,volume_voxels,volume_mm3\\n")
         for label_id, label_name in sorted(lut.items(), key=lambda x: int(x[0])):
             count   = int(np.sum(data_int == int(label_id)))
             vol_mm3 = count * vox_vol
-            out.write(f"{prefix},{label_name},{count},{vol_mm3:.4f}\\n")
+            out.write(f"{subject_id},{session_id},{label_name},{count},{vol_mm3:.4f}\\n")
 else:
     # WM mode: list of binary/TDI masks.
     # Equivalent per mask to:
@@ -64,22 +68,25 @@ else:
     mask_files = sorted("${rois_str}".split())
 
     with open(output_file, 'w') as out:
-        out.write("subject_id,region,volume_voxels,volume_mm3\\n")
+        out.write("subject_id,session,bundle,volume_voxels,volume_mm3\\n")
         for mask_file in mask_files:
-            region = os.path.basename(mask_file)
+            bundle = os.path.basename(mask_file)
             for ext in ('.nii.gz', '.nii'):
-                if region.endswith(ext):
-                    region = region[:-len(ext)]
+                if bundle.endswith(ext):
+                    bundle = bundle[:-len(ext)]
                     break
+            # Strip the session prefix that ANTSAPPLYTRANSFORMS adds to output filenames
+            if session_id and bundle.startswith(session_id + "_"):
+                bundle = bundle[len(session_id) + 1:]
             for s in substrs:
-                region = region.removeprefix(s).removesuffix(s)
+                bundle = bundle.removeprefix(s).removesuffix(s)
 
             img     = nib.load(mask_file)
             data    = img.get_fdata()
             vox_vol = float(np.prod(img.header.get_zooms()[:3]))
             count   = int(np.sum(data > 0))
             vol_mm3 = count * vox_vol
-            out.write(f"{prefix},{region},{count},{vol_mm3:.4f}\\n")
+            out.write(f"{subject_id},{session_id},{bundle},{count},{vol_mm3:.4f}\\n")
 
 with open("versions.yml", "w") as v:
     v.write('"${task.process}":\\n')

--- a/modules/nf-neuro/stats/roivolumes/main.nf
+++ b/modules/nf-neuro/stats/roivolumes/main.nf
@@ -80,13 +80,12 @@ else:
             count   = int(np.sum(data > 0))
             vol_mm3 = count * vox_vol
             out.write(f"{prefix},{region},{count},{vol_mm3:.4f}\\n")
-PYEOF
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        nibabel: \$(python3 -c "import nibabel; print(nibabel.__version__)")
-        numpy: \$(python3 -c "import numpy; print(numpy.__version__)")
-    END_VERSIONS
+with open("versions.yml", "w") as v:
+    v.write('"${task.process}":\\n')
+    v.write(f"    nibabel: {nib.__version__}\\n")
+    v.write(f"    numpy: {np.__version__}\\n")
+PYEOF
     """
 
     stub:
@@ -95,10 +94,12 @@ PYEOF
     """
     touch ${prefix}_${suffix}.csv
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        nibabel: \$(python3 -c "import nibabel; print(nibabel.__version__)")
-        numpy: \$(python3 -c "import numpy; print(numpy.__version__)")
-    END_VERSIONS
+    python3 -c "
+with open('versions.yml', 'w') as v:
+    import nibabel, numpy
+    v.write('\"${task.process}\":\\n')
+    v.write(f'    nibabel: {nibabel.__version__}\\n')
+    v.write(f'    numpy: {numpy.__version__}\\n')
+"
     """
 }

--- a/modules/nf-neuro/stats/roivolumes/main.nf
+++ b/modules/nf-neuro/stats/roivolumes/main.nf
@@ -2,7 +2,8 @@ process STATS_ROIVOLUMES {
     tag "$meta.id"
     label 'process_single'
 
-    container "docker.io/scilus/scilpy:2.2.2_cpu"
+    conda "${moduleDir}/environment.yml"
+    container "${ 'community.wave.seqera.io/library/nibabel_numpy:4148b92a8cbc6976' }"
 
     input:
     tuple val(meta), path(rois), path(rois_lut)  /* optional, input = [] */
@@ -21,7 +22,7 @@ process STATS_ROIVOLUMES {
     def use_label_py      = use_label ? "True" : "False"
     def substrs_to_remove = task.ext.key_substrs_to_remove ?: []
     def substrs_json      = groovy.json.JsonOutput.toJson(substrs_to_remove)
-    // For WM mode: rois is a list; join paths as space-separated string for Python to split
+    // For labels mode: rois is a list; join paths as space-separated string for Python to split
     def rois_str          = rois instanceof List ? rois.join(' ') : "${rois}"
     def subject_id        = meta.id ?: ""
     def session_id        = meta.session ?: ""
@@ -44,7 +45,7 @@ run_id     = "${run_id}"
 output_file = f"{prefix}_{suffix}.csv"
 
 if use_label:
-    # GM mode: single label atlas — load once, count all labels in one pass.
+    # Labelmap mode: single atlas/labelmap image — load once, count all labels in one pass.
     # Equivalent per label to:
     #   mrcalc atlas <label_id> -eq mask + mrstats mask -mask mask -output count
     img  = nib.load("${rois}")
@@ -63,7 +64,7 @@ if use_label:
             vol_mm3 = count * vox_vol
             out.write(f"{subject_id},{session_id},{run_id},{label_name},{count},{vol_mm3:.4f}\\n")
 else:
-    # WM mode: list of binary/TDI masks.
+    # Labels mode: list of binary/weighted ROI masks, one file per label.
     # Equivalent per mask to:
     #   mrstats mask -mask mask -output count
     # np.sum(data > 0) counts finite non-zero voxels (NaN > 0 == False, excluded).

--- a/modules/nf-neuro/stats/roivolumes/main.nf
+++ b/modules/nf-neuro/stats/roivolumes/main.nf
@@ -25,6 +25,7 @@ process STATS_ROIVOLUMES {
     def rois_str          = rois instanceof List ? rois.join(' ') : "${rois}"
     def subject_id        = meta.id ?: ""
     def session_id        = meta.session ?: ""
+    def run_id            = meta.run ?: ""
     """
     python3 << 'PYEOF'
 import nibabel as nib
@@ -38,6 +39,7 @@ use_label  = ${use_label_py}
 substrs    = ${substrs_json}
 subject_id = "${subject_id}"
 session_id = "${session_id}"
+run_id     = "${run_id}"
 
 output_file = f"{prefix}_{suffix}.csv"
 
@@ -55,11 +57,11 @@ if use_label:
         lut = json.load(f)
 
     with open(output_file, 'w') as out:
-        out.write("subject_id,session,region,volume_voxels,volume_mm3\\n")
+        out.write("subject_id,session,run,region,volume_voxels,volume_mm3\\n")
         for label_id, label_name in sorted(lut.items(), key=lambda x: int(x[0])):
             count   = int(np.sum(data_int == int(label_id)))
             vol_mm3 = count * vox_vol
-            out.write(f"{subject_id},{session_id},{label_name},{count},{vol_mm3:.4f}\\n")
+            out.write(f"{subject_id},{session_id},{run_id},{label_name},{count},{vol_mm3:.4f}\\n")
 else:
     # WM mode: list of binary/TDI masks.
     # Equivalent per mask to:
@@ -68,7 +70,7 @@ else:
     mask_files = sorted("${rois_str}".split())
 
     with open(output_file, 'w') as out:
-        out.write("subject_id,session,bundle,volume_voxels,volume_mm3\\n")
+        out.write("subject_id,session,run,bundle,volume_voxels,volume_mm3\\n")
         for mask_file in mask_files:
             bundle = os.path.basename(mask_file)
             for ext in ('.nii.gz', '.nii'):
@@ -86,7 +88,7 @@ else:
             vox_vol = float(np.prod(img.header.get_zooms()[:3]))
             count   = int(np.sum(data > 0))
             vol_mm3 = count * vox_vol
-            out.write(f"{subject_id},{session_id},{bundle},{count},{vol_mm3:.4f}\\n")
+            out.write(f"{subject_id},{session_id},{run_id},{bundle},{count},{vol_mm3:.4f}\\n")
 
 with open("versions.yml", "w") as v:
     v.write('"${task.process}":\\n')

--- a/modules/nf-neuro/stats/roivolumes/meta.yml
+++ b/modules/nf-neuro/stats/roivolumes/meta.yml
@@ -71,10 +71,11 @@ output:
       - "*_volumes.csv":
           type: file
           description: |
-            CSV file with columns: sid, session, run, <roi>, volume_voxels, volume_mm3.
-            One row per input mask file in labels mode (use_label = false, ROI column
-            named `bundle`), or one row per LUT entry in atlas/labelmap mode
-            (use_label = true, ROI column named `region`).
+            CSV file with columns: sid, session, run, roi, volume_voxels, volume_mm3.
+            The column set is identical in both modes: one row per input mask file in
+            labels mode (use_label = false, `roi` holding the name derived from the
+            filename), or one row per LUT entry in atlas/labelmap mode
+            (use_label = true, `roi` holding the LUT region name).
             The filename is `{prefix}_volumes.csv`, or `{prefix}_{first_suffix}_volumes.csv`
             when the `first_suffix` arg is set.
           pattern: "*_volumes.csv"

--- a/modules/nf-neuro/stats/roivolumes/meta.yml
+++ b/modules/nf-neuro/stats/roivolumes/meta.yml
@@ -1,7 +1,8 @@
 name: "stats_roivolumes"
-description: Module to compute voxel counts and volumes (mm³) of ROI masks or
-  label regions from a label atlas, using nibabel and numpy (no external tools
-  required).
+description: Module to compute voxel counts and volumes (mm³) of ROIs, either from a
+  list of individual mask files (labels mode) or from a single atlas/labelmap image
+  paired with a Look-Up Table (atlas/labelmap mode), using nibabel and numpy (no
+  external tools required).
 keywords:
   - nifti
   - volume
@@ -27,9 +28,23 @@ input:
     - rois:
         type: file
         description: |
-          In WM mode (use_label = false): list of binary or weighted NIfTI mask files,
-          one per bundle. In GM mode (use_label = true): single NIfTI label atlas where
-          each integer value corresponds to a region defined in the Look-Up Table (LUT).
+          The module operates in one of two modes, selected with the `use_label` arg.
+
+          **Labels mode** (use_label = false): a list of binary or weighted NIfTI mask
+          files, one file per ROI (e.g. bundle masks, tissue masks, TDI maps). One row
+          is emitted per input file. The ROI name written to the CSV is derived from the
+          filename: the directory and the `.nii`/`.nii.gz` extension are stripped, then
+          every substring listed in `key_substrs_to_remove` is removed from the start
+          and the end of the remaining basename. Rows are sorted by input file path.
+          e.g. with key_substrs_to_remove = ["sub-01_", "_warped"], the input file
+          `sub-01_AF_L_warped.nii.gz` yields the ROI name `AF_L`.
+
+          **Atlas/labelmap mode** (use_label = true): a single NIfTI atlas (labelmap)
+          image where each integer voxel value identifies a region. One row is emitted
+          per entry of the Look-Up Table (LUT), named after the LUT value and ordered by
+          ascending integer label index. Values are rounded to the nearest integer
+          before counting, so a labelmap resampled or warped with a MultiLabel
+          interpolator can be passed directly.
         pattern: "*.{nii,nii.gz}"
         ontologies:
           - edam: http://edamontology.org/format_4001
@@ -37,7 +52,10 @@ input:
         type: file
         description: |
           JSON Look-Up Table (LUT) mapping integer label indices (as strings) to
-          region names. Required when use_label = true, otherwise pass [].
+          region names. Required in atlas/labelmap mode (use_label = true); it defines
+          both which labels are reported and the name given to each one. Not used in
+          labels mode (use_label = false), where names come from the filenames —
+          pass [] instead.
           e.g. {"17": "Left-Hippocampus", "53": "Right-Hippocampus"}
         pattern: "*.json"
         mandatory: false
@@ -53,8 +71,12 @@ output:
       - "*_volumes.csv":
           type: file
           description: |
-            CSV file with columns: subject_id, region, volume_voxels, volume_mm3.
-            One row per bundle (WM mode) or per label (GM mode).
+            CSV file with columns: sid, session, run, <roi>, volume_voxels, volume_mm3.
+            One row per input mask file in labels mode (use_label = false, ROI column
+            named `bundle`), or one row per LUT entry in atlas/labelmap mode
+            (use_label = true, ROI column named `region`).
+            The filename is `{prefix}_volumes.csv`, or `{prefix}_{first_suffix}_volumes.csv`
+            when the `first_suffix` arg is set.
           pattern: "*_volumes.csv"
           ontologies:
             - edam: http://edamontology.org/format_3752
@@ -76,9 +98,11 @@ args:
   - use_label:
       type: boolean
       description: |
-        If true, rois is interpreted as a label atlas and rois_lut must be provided.
-        Volumes are computed per label. If false, rois is a list of binary masks and
-        volume is computed per mask file (number of non-zero voxels × voxel volume).
+        Selects the mode. If true (atlas/labelmap mode), rois is interpreted as a
+        single atlas/labelmap image and rois_lut must be provided; one volume is
+        computed per LUT entry, counting voxels whose rounded value equals the label
+        index. If false (labels mode), rois is a list of mask files and one volume is
+        computed per file (number of non-zero voxels × voxel volume).
       default: false
   - first_suffix:
       type: string
@@ -89,7 +113,10 @@ args:
   - key_substrs_to_remove:
       type: list
       description: |
-        List of substrings to remove from region names (WM mode only).
-        Applied via removeprefix/removesuffix to strip subject ID prefix and
-        warp suffixes, e.g. ["sub-01_", "_mask_warped", "_warped"].
+        List of substrings to strip from the ROI names derived from the input
+        filenames (labels mode only; ignored in atlas/labelmap mode, where names
+        come from the LUT). Each substring is removed from both the start and the
+        end of the extension-stripped basename, so it is meant for subject ID
+        prefixes and processing suffixes,
+        e.g. ["sub-01_", "_mask_warped", "_warped"].
       default: []

--- a/modules/nf-neuro/stats/roivolumes/meta.yml
+++ b/modules/nf-neuro/stats/roivolumes/meta.yml
@@ -1,0 +1,88 @@
+name: "stats_roivolumes"
+description: Module to compute voxel counts and volumes (mm³) of ROI masks or label
+  regions from a label atlas, using nibabel and numpy (no external tools required).
+keywords:
+  - nifti
+  - volume
+  - stats
+  - rois
+  - labels
+tools:
+  - nibabel:
+      description: Python package for reading and writing neuroimaging file formats.
+      homepage: https://nipy.org/nibabel/
+      identifier: ""
+  - numpy:
+      description: Fundamental package for scientific computing with Python.
+      homepage: https://numpy.org/
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'test', single_end:false ]`
+    - rois:
+        type: file
+        description: |
+          In WM mode (use_label = false): list of binary or weighted NIfTI mask files,
+          one per bundle. In GM mode (use_label = true): single NIfTI label atlas where
+          each integer value corresponds to a region defined in the LUT.
+        pattern: "*.{nii,nii.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_4001 # NIFTI format
+    - rois_lut:
+        type: file
+        description: |
+          JSON LUT mapping integer label indices (as strings) to region names.
+          Required when use_label = true, otherwise pass [].
+          e.g. {"17": "Left-Hippocampus", "53": "Right-Hippocampus"}
+        pattern: "*.json"
+        mandatory: false
+        ontologies:
+          - edam: http://edamontology.org/format_3464 # JSON
+args:
+  - use_label:
+      type: boolean
+      description: |
+        If true, rois is interpreted as a label atlas and rois_lut must be provided.
+        Volumes are computed per label. If false, rois is a list of binary masks and
+        volume is computed per mask file (number of non-zero voxels × voxel volume).
+      default: false
+  - first_suffix:
+      type: string
+      description: |
+        Optional string inserted before "_volumes" in the output filename.
+        e.g. "atlas-iit-gm" produces "{prefix}_atlas-iit-gm_volumes.csv".
+      default: ""
+  - key_substrs_to_remove:
+      type: list
+      description: |
+        List of substrings to remove from region names (WM mode only).
+        Applied via removeprefix/removesuffix to strip subject ID prefix and
+        warp suffixes, e.g. ["sub-01_", "_mask_warped", "_warped"].
+      default: []
+output:
+  volumes:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'test', single_end:false ]`
+      - "*_volumes.csv":
+          type: file
+          description: |
+            CSV file with columns: subject_id, region, volume_voxels, volume_mm3.
+            One row per bundle (WM mode) or per label (GM mode).
+          pattern: "*_volumes.csv"
+          ontologies:
+            - edam: http://edamontology.org/format_3752 # CSV
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@baptisp"

--- a/modules/nf-neuro/stats/roivolumes/meta.yml
+++ b/modules/nf-neuro/stats/roivolumes/meta.yml
@@ -29,15 +29,15 @@ input:
         description: |
           In WM mode (use_label = false): list of binary or weighted NIfTI mask files,
           one per bundle. In GM mode (use_label = true): single NIfTI label atlas where
-          each integer value corresponds to a region defined in the LUT.
+          each integer value corresponds to a region defined in the Look-Up Table (LUT).
         pattern: "*.{nii,nii.gz}"
         ontologies:
           - edam: http://edamontology.org/format_4001
     - rois_lut:
         type: file
         description: |
-          JSON LUT mapping integer label indices (as strings) to region names.
-          Required when use_label = true, otherwise pass [].
+          JSON Look-Up Table (LUT) mapping integer label indices (as strings) to
+          region names. Required when use_label = true, otherwise pass [].
           e.g. {"17": "Left-Hippocampus", "53": "Right-Hippocampus"}
         pattern: "*.json"
         mandatory: false

--- a/modules/nf-neuro/stats/roivolumes/meta.yml
+++ b/modules/nf-neuro/stats/roivolumes/meta.yml
@@ -1,6 +1,7 @@
 name: "stats_roivolumes"
-description: Module to compute voxel counts and volumes (mm³) of ROI masks or label
-  regions from a label atlas, using nibabel and numpy (no external tools required).
+description: Module to compute voxel counts and volumes (mm³) of ROI masks or
+  label regions from a label atlas, using nibabel and numpy (no external tools
+  required).
 keywords:
   - nifti
   - volume
@@ -9,7 +10,8 @@ keywords:
   - labels
 tools:
   - nibabel:
-      description: Python package for reading and writing neuroimaging file formats.
+      description: Python package for reading and writing neuroimaging file
+        formats.
       homepage: https://nipy.org/nibabel/
       identifier: ""
   - numpy:
@@ -30,7 +32,7 @@ input:
           each integer value corresponds to a region defined in the LUT.
         pattern: "*.{nii,nii.gz}"
         ontologies:
-          - edam: http://edamontology.org/format_4001 # NIFTI format
+          - edam: http://edamontology.org/format_4001
     - rois_lut:
         type: file
         description: |
@@ -40,7 +42,36 @@ input:
         pattern: "*.json"
         mandatory: false
         ontologies:
-          - edam: http://edamontology.org/format_3464 # JSON
+          - edam: http://edamontology.org/format_3464
+output:
+  volumes:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'test', single_end:false ]`
+      - "*_volumes.csv":
+          type: file
+          description: |
+            CSV file with columns: subject_id, region, volume_voxels, volume_mm3.
+            One row per bundle (WM mode) or per label (GM mode).
+          pattern: "*_volumes.csv"
+          ontologies:
+            - edam: http://edamontology.org/format_3752
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750
+topics:
+  versions:
+    - versions.yml:
+        type: string
+        description: The name of the process
+authors:
+  - "@baptisp"
 args:
   - use_label:
       type: boolean
@@ -62,27 +93,3 @@ args:
         Applied via removeprefix/removesuffix to strip subject ID prefix and
         warp suffixes, e.g. ["sub-01_", "_mask_warped", "_warped"].
       default: []
-output:
-  volumes:
-    - - meta:
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. `[ id:'test', single_end:false ]`
-      - "*_volumes.csv":
-          type: file
-          description: |
-            CSV file with columns: subject_id, region, volume_voxels, volume_mm3.
-            One row per bundle (WM mode) or per label (GM mode).
-          pattern: "*_volumes.csv"
-          ontologies:
-            - edam: http://edamontology.org/format_3752 # CSV
-  versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
-authors:
-  - "@baptisp"

--- a/modules/nf-neuro/stats/roivolumes/meta.yml
+++ b/modules/nf-neuro/stats/roivolumes/meta.yml
@@ -109,7 +109,7 @@ args:
       type: string
       description: |
         Optional string inserted before "_volumes" in the output filename.
-        e.g. "atlas-iit-gm" produces "{prefix}_atlas-iit-gm_volumes.csv".
+        e.g. "atlas-brainnetome" produces "{prefix}_atlas-brainnetome_volumes.csv".
       default: ""
   - key_substrs_to_remove:
       type: list

--- a/modules/nf-neuro/stats/roivolumes/tests/main.nf.test
+++ b/modules/nf-neuro/stats/roivolumes/tests/main.nf.test
@@ -1,0 +1,112 @@
+nextflow_process {
+
+    name "Test Process STATS_ROIVOLUMES"
+    script "../main.nf"
+    process "STATS_ROIVOLUMES"
+
+    tag "modules"
+    tag "modules_nfneuro"
+    tag "stats"
+    tag "stats/roivolumes"
+
+    tag "subworkflows"
+    tag "subworkflows/load_test_data"
+
+    setup {
+        run("LOAD_TEST_DATA", alias: "LOAD_DATA") {
+            script "../../../../../subworkflows/nf-neuro/load_test_data/main.nf"
+            process {
+                """
+                input[0] = channel.from( [ "tractometry.zip", "plot.zip" ] )
+                input[1] = "test.load-test-data"
+                """
+            }
+        }
+    }
+
+    test("stats - roi volumes - WM binary masks") {
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+                    .branch{
+                        tractometry: it.simpleName == "tractometry"
+                    }
+                input[0] = ch_split_test_data.tractometry.map{
+                    test_data_directory -> [
+                        [ id:'test', single_end:false ],
+                        [
+                            file("\${test_data_directory}/IFGWM.nii.gz"),
+                            file("\${test_data_directory}/IFGWM_uni.nii.gz")
+                        ],
+                        []
+                    ]
+                }
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("stats - roi volumes - GM label atlas") {
+
+        config "./nextflow_label.config"
+
+        when {
+            process {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+                    .branch{
+                        plot: it.simpleName == "plot"
+                    }
+                input[0] = ch_split_test_data.plot.map{
+                    test_data_directory -> [
+                        [ id:'test', single_end:false ],
+                        file("\${test_data_directory}/atlas_brainnetome.nii.gz"),
+                        file("\${test_data_directory}/atlas_brainnetome.json")
+                    ]
+                }
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("stats - roi volumes - stub-run") {
+        tag "stub"
+        options "-stub-run"
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'test', single_end:false ],
+                    [ file(params.modules_testdata_base_path + 'nifti/fa.nii.gz', checkIfExists: true) ],
+                    []
+                ])
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-neuro/stats/roivolumes/tests/main.nf.test
+++ b/modules/nf-neuro/stats/roivolumes/tests/main.nf.test
@@ -24,7 +24,7 @@ nextflow_process {
         }
     }
 
-    test("stats - roi volumes - WM binary masks") {
+    test("stats - roi volumes - labels mode") {
 
         config "./nextflow.config"
 
@@ -56,7 +56,7 @@ nextflow_process {
         }
     }
 
-    test("stats - roi volumes - GM label atlas") {
+    test("stats - roi volumes - atlas labelmap mode") {
 
         config "./nextflow_label.config"
 

--- a/modules/nf-neuro/stats/roivolumes/tests/main.nf.test
+++ b/modules/nf-neuro/stats/roivolumes/tests/main.nf.test
@@ -40,7 +40,7 @@ nextflow_process {
                         [ id:'test', single_end:false ],
                         [
                             file("\${test_data_directory}/IFGWM.nii.gz"),
-                            file("\${test_data_directory}/IFGWM_uni.nii.gz")
+                            file("\${test_data_directory}/IFGWM_labels_map.nii.gz")
                         ],
                         []
                     ]
@@ -96,7 +96,7 @@ nextflow_process {
                 """
                 input[0] = channel.of([
                     [ id:'test', single_end:false ],
-                    [ file(params.modules_testdata_base_path + 'nifti/fa.nii.gz', checkIfExists: true) ],
+                    [ file('stub.nii.gz', checkIfExists: false) ],
                     []
                 ])
                 """

--- a/modules/nf-neuro/stats/roivolumes/tests/main.nf.test.snap
+++ b/modules/nf-neuro/stats/roivolumes/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "stats - roi volumes - GM label atlas": {
+    "stats - roi volumes - labels mode": {
         "content": [
             {
                 "0": [
@@ -8,14 +8,14 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_atlas-brainnetome_volumes.csv:md5,6eeeeb6e95ee5800557ac7c48f6dc5c1"
+                        "test_volumes.csv:md5,2ce81edb22441d2338562ac25fa0d8b5"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,3905b6375ddd03a381e56dd2d0f7914f"
+                    "versions.yml:md5,849ae3467d1ff56248e9388878ac2b48"
                 ],
                 "versions": [
-                    "versions.yml:md5,3905b6375ddd03a381e56dd2d0f7914f"
+                    "versions.yml:md5,849ae3467d1ff56248e9388878ac2b48"
                 ],
                 "volumes": [
                     [
@@ -23,18 +23,18 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_atlas-brainnetome_volumes.csv:md5,6eeeeb6e95ee5800557ac7c48f6dc5c1"
+                        "test_volumes.csv:md5,2ce81edb22441d2338562ac25fa0d8b5"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-07-24T16:16:41.185081644",
+        "timestamp": "2026-08-22T14:22:13.510833899",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"
         }
     },
-    "stats - roi volumes - WM binary masks": {
+    "stats - roi volumes - atlas labelmap mode": {
         "content": [
             {
                 "0": [
@@ -43,14 +43,14 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_volumes.csv:md5,2ce81edb22441d2338562ac25fa0d8b5"
+                        "test_atlas-brainnetome_volumes.csv:md5,6eeeeb6e95ee5800557ac7c48f6dc5c1"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,3905b6375ddd03a381e56dd2d0f7914f"
+                    "versions.yml:md5,849ae3467d1ff56248e9388878ac2b48"
                 ],
                 "versions": [
-                    "versions.yml:md5,3905b6375ddd03a381e56dd2d0f7914f"
+                    "versions.yml:md5,849ae3467d1ff56248e9388878ac2b48"
                 ],
                 "volumes": [
                     [
@@ -58,12 +58,12 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_volumes.csv:md5,2ce81edb22441d2338562ac25fa0d8b5"
+                        "test_atlas-brainnetome_volumes.csv:md5,6eeeeb6e95ee5800557ac7c48f6dc5c1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-07-24T16:16:37.763908436",
+        "timestamp": "2026-08-22T14:22:16.846349724",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"
@@ -82,10 +82,10 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,dc45e28ef07a1823d8e8adc5a8b07651"
+                    "versions.yml:md5,5f4cc6ba9cd16c9dc450e14ad64ae246"
                 ],
                 "versions": [
-                    "versions.yml:md5,dc45e28ef07a1823d8e8adc5a8b07651"
+                    "versions.yml:md5,5f4cc6ba9cd16c9dc450e14ad64ae246"
                 ],
                 "volumes": [
                     [
@@ -98,7 +98,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-24T16:16:44.456168199",
+        "timestamp": "2026-08-22T14:22:19.887529693",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/modules/nf-neuro/stats/roivolumes/tests/main.nf.test.snap
+++ b/modules/nf-neuro/stats/roivolumes/tests/main.nf.test.snap
@@ -1,0 +1,107 @@
+{
+    "stats - roi volumes - GM label atlas": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_atlas-brainnetome_volumes.csv:md5,6eeeeb6e95ee5800557ac7c48f6dc5c1"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,3905b6375ddd03a381e56dd2d0f7914f"
+                ],
+                "versions": [
+                    "versions.yml:md5,3905b6375ddd03a381e56dd2d0f7914f"
+                ],
+                "volumes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_atlas-brainnetome_volumes.csv:md5,6eeeeb6e95ee5800557ac7c48f6dc5c1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-24T16:16:41.185081644",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
+    "stats - roi volumes - WM binary masks": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_volumes.csv:md5,2ce81edb22441d2338562ac25fa0d8b5"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,3905b6375ddd03a381e56dd2d0f7914f"
+                ],
+                "versions": [
+                    "versions.yml:md5,3905b6375ddd03a381e56dd2d0f7914f"
+                ],
+                "volumes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_volumes.csv:md5,2ce81edb22441d2338562ac25fa0d8b5"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-24T16:16:37.763908436",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
+    "stats - roi volumes - stub-run": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_volumes.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,dc45e28ef07a1823d8e8adc5a8b07651"
+                ],
+                "versions": [
+                    "versions.yml:md5,dc45e28ef07a1823d8e8adc5a8b07651"
+                ],
+                "volumes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_volumes.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-24T16:16:44.456168199",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    }
+}

--- a/modules/nf-neuro/stats/roivolumes/tests/main.nf.test.snap
+++ b/modules/nf-neuro/stats/roivolumes/tests/main.nf.test.snap
@@ -8,7 +8,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_volumes.csv:md5,2ce81edb22441d2338562ac25fa0d8b5"
+                        "test_volumes.csv:md5,f734baac77015682e53adafefbe09940"
                     ]
                 ],
                 "1": [
@@ -23,12 +23,12 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_volumes.csv:md5,2ce81edb22441d2338562ac25fa0d8b5"
+                        "test_volumes.csv:md5,f734baac77015682e53adafefbe09940"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-22T14:22:13.510833899",
+        "timestamp": "2026-08-22T16:46:55.123632653",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"
@@ -43,7 +43,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_atlas-brainnetome_volumes.csv:md5,6eeeeb6e95ee5800557ac7c48f6dc5c1"
+                        "test_atlas-brainnetome_volumes.csv:md5,61a5dde7b09b773e34508cc479d1dfd5"
                     ]
                 ],
                 "1": [
@@ -58,12 +58,12 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_atlas-brainnetome_volumes.csv:md5,6eeeeb6e95ee5800557ac7c48f6dc5c1"
+                        "test_atlas-brainnetome_volumes.csv:md5,61a5dde7b09b773e34508cc479d1dfd5"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-22T14:22:16.846349724",
+        "timestamp": "2026-08-22T16:46:59.22838886",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/modules/nf-neuro/stats/roivolumes/tests/nextflow.config
+++ b/modules/nf-neuro/stats/roivolumes/tests/nextflow.config
@@ -1,6 +1,7 @@
 process {
     withName: "STATS_ROIVOLUMES" {
         publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+        ext.prefix = { meta.id }
         ext.use_label = false
         ext.key_substrs_to_remove = { ["${task.ext.prefix}_", "_warped"] }
     }

--- a/modules/nf-neuro/stats/roivolumes/tests/nextflow.config
+++ b/modules/nf-neuro/stats/roivolumes/tests/nextflow.config
@@ -1,0 +1,7 @@
+process {
+    withName: "STATS_ROIVOLUMES" {
+        publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+        ext.use_label = false
+        ext.key_substrs_to_remove = { ["${task.ext.prefix}_", "_warped"] }
+    }
+}

--- a/modules/nf-neuro/stats/roivolumes/tests/nextflow_label.config
+++ b/modules/nf-neuro/stats/roivolumes/tests/nextflow_label.config
@@ -1,0 +1,7 @@
+process {
+    withName: "STATS_ROIVOLUMES" {
+        publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+        ext.use_label = true
+        ext.first_suffix = "atlas-brainnetome"
+    }
+}

--- a/modules/nf-neuro/stats/roivolumes/tests/tags.yml
+++ b/modules/nf-neuro/stats/roivolumes/tests/tags.yml
@@ -1,0 +1,2 @@
+stats/roivolumes:
+  - "modules/nf-neuro/stats/roivolumes/**"

--- a/subworkflows/nf-neuro/atlas_iit/main.nf
+++ b/subworkflows/nf-neuro/atlas_iit/main.nf
@@ -66,6 +66,53 @@ def fetch_iit_atlas_tdi(bundleMapsUrl, dest, thresholds) {
     return output_dir + "bundle_maps/IIT_bundles"
 }
 
+// Fetch the IIT GM Desikan parcellation atlas
+def fetch_iit_gm_desikan_atlas(atlasUrl, dest) {
+    def outFile = new File("$dest/IIT_GM_Desikan_atlas.nii.gz")
+    if (!outFile.exists()) {
+        download_file(atlasUrl, outFile.absolutePath)
+    }
+    return outFile
+}
+
+// The IIT GM LUT is distributed as a tab-separated TXT (index R G B name).
+// STATS_ROIVOLUMES and STATS_METRICSINROI both expect a JSON {index: name} map.
+def convert_lut_txt_to_json(File lutFile, File jsonFile) {
+    def lutMap = [:]
+    lutFile.eachLine { line ->
+        def trimmed = line.trim()
+        if (trimmed && !trimmed.startsWith('#')) {
+            def parts = trimmed.split(/\s+/, 5)
+            if (parts.size() == 5) {
+                lutMap[parts[0]] = parts[4].replaceAll('"', '').trim()
+            }
+        }
+    }
+    jsonFile.text = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(lutMap))
+}
+
+def fetch_and_convert_iit_gm_lut(lutUrl, dest) {
+    def lutFile  = new File("$dest/LUT_GM_Desikan_0to1.txt")
+    def jsonFile = new File("$dest/IIT_GM_Desikan_lut.json")
+    if (!jsonFile.exists()) {
+        if (!lutFile.exists()) {
+            download_file(lutUrl, lutFile.absolutePath)
+        }
+        convert_lut_txt_to_json(lutFile, jsonFile)
+    }
+    return jsonFile
+}
+
+// Convert a user-provided local TXT LUT to JSON, so offline/HPC runs need no download.
+def convert_local_iit_gm_lut(localTxtPath, dest) {
+    def lutFile  = new File(localTxtPath)
+    def jsonFile = new File("$dest/IIT_GM_Desikan_lut.json")
+    if (!jsonFile.exists()) {
+        convert_lut_txt_to_json(lutFile, jsonFile)
+    }
+    return jsonFile
+}
+
 def get_tdi_thresholds() {
     // Those thresholds were recommended by the authors of the IIT atlas
     // to generate the bundle masks from the track density images.
@@ -220,8 +267,45 @@ workflow ATLAS_IIT {
                 })
         }
 
+        // Fetch the IIT GM Desikan parcellation atlas and its LUT (only when requested)
+        ch_gm_atlas = channel.empty()
+        ch_gm_lut   = channel.empty()
+
+        if (options.run_gm_roimetrics) {
+            def gm_dest = "${workflow.workDir}/atlas_iit/gm"
+            new File(gm_dest).mkdirs()
+
+            if (options.atlas_iit_gm_atlas) {
+                ch_gm_atlas = channel.fromPath(options.atlas_iit_gm_atlas, checkIfExists: true)
+            }
+            else {
+                def gm_atlas_file = fetch_iit_gm_desikan_atlas(
+                    "https://www.nitrc.org/frs/download.php/11328/IIT_GM_Desikan_atlas.nii.gz",
+                    gm_dest
+                )
+                ch_gm_atlas = channel.fromPath(gm_atlas_file.absolutePath, checkIfExists: true)
+            }
+
+            if (options.atlas_iit_gm_lut) {
+                // Accept either the raw NITRC TXT (converted locally) or a ready-made JSON
+                def gm_lut_file = options.atlas_iit_gm_lut.endsWith(".txt")
+                    ? convert_local_iit_gm_lut(options.atlas_iit_gm_lut, gm_dest).absolutePath
+                    : options.atlas_iit_gm_lut
+                ch_gm_lut = channel.fromPath(gm_lut_file, checkIfExists: true)
+            }
+            else {
+                def gm_lut_file = fetch_and_convert_iit_gm_lut(
+                    "https://www.nitrc.org/frs/download.php/11343/LUT_GM_Desikan_0to1.txt",
+                    gm_dest
+                )
+                ch_gm_lut = channel.fromPath(gm_lut_file.absolutePath, checkIfExists: true)
+            }
+        }
+
     emit:
-        b0 = ch_b0
-        bundles = ch_bundles
+        b0       = ch_b0
+        bundles  = ch_bundles
+        gm_atlas = ch_gm_atlas
+        gm_lut   = ch_gm_lut
         versions = ch_versions
 }

--- a/subworkflows/nf-neuro/atlas_iit/main.nf
+++ b/subworkflows/nf-neuro/atlas_iit/main.nf
@@ -271,7 +271,7 @@ workflow ATLAS_IIT {
         ch_gm_atlas = channel.empty()
         ch_gm_lut   = channel.empty()
 
-        if (options.run_gm_roimetrics) {
+        if (options.fetch_gm_desikan) {
             def gm_dest = "${workflow.workDir}/atlas_iit/gm"
             new File(gm_dest).mkdirs()
 

--- a/subworkflows/nf-neuro/atlas_iit/meta.yml
+++ b/subworkflows/nf-neuro/atlas_iit/meta.yml
@@ -48,6 +48,18 @@ input:
           type: string
           description: Path to a directory containing IIT bundle masks. If provided, these inputs will be used instead of downloading and processing the bundle masks.
           default: null
+        run_gm_roimetrics:
+          type: boolean
+          description: If 'true', also fetch the IIT GM Desikan parcellation atlas and its Look-Up Table, emitted on the `gm_atlas` and `gm_lut` channels. Both channels stay empty when this is 'false'.
+          default: false
+        atlas_iit_gm_atlas:
+          type: string
+          description: Path to the IIT GM Desikan atlas (IIT_GM_Desikan_atlas.nii.gz). If provided, this input will be used instead of downloading the atlas from NITRC.
+          default: null
+        atlas_iit_gm_lut:
+          type: string
+          description: Path to the IIT GM Desikan Look-Up Table. Accepts either a pre-converted JSON file or the raw tab-separated TXT distributed by NITRC (LUT_GM_Desikan_0to1.txt), which is converted to JSON locally without requiring internet access. If provided, this input will be used instead of downloading the LUT from NITRC.
+          default: null
 output:
   - bundle_masks:
       type: file
@@ -71,6 +83,30 @@ output:
       pattern: "*_b0.nii.gz"
       ontologies:
         - edam: http://edamontology.org/format_4001 # NIFTI format
+  - gm_atlas:
+      type: file
+      description: |
+        IIT GM Desikan parcellation atlas, in the atlas' template space.
+        Empty unless `run_gm_roimetrics` is enabled.
+      structure:
+        - gm_atlas:
+            type: file
+            description: GM Desikan parcellation labelmap file.
+      pattern: "*.nii.gz"
+      ontologies:
+        - edam: http://edamontology.org/format_4001 # NIFTI format
+  - gm_lut:
+      type: file
+      description: |
+        JSON Look-Up Table mapping the GM Desikan label indices to region names.
+        Empty unless `run_gm_roimetrics` is enabled.
+      structure:
+        - gm_lut:
+            type: file
+            description: GM Desikan Look-Up Table, as JSON.
+      pattern: "*.json"
+      ontologies:
+        - edam: http://edamontology.org/format_3464 # JSON format
   - versions:
       type: file
       description: |

--- a/subworkflows/nf-neuro/atlas_iit/meta.yml
+++ b/subworkflows/nf-neuro/atlas_iit/meta.yml
@@ -48,7 +48,7 @@ input:
           type: string
           description: Path to a directory containing IIT bundle masks. If provided, these inputs will be used instead of downloading and processing the bundle masks.
           default: null
-        run_gm_roimetrics:
+        fetch_gm_desikan:
           type: boolean
           description: If 'true', also fetch the IIT GM Desikan parcellation atlas and its Look-Up Table, emitted on the `gm_atlas` and `gm_lut` channels. Both channels stay empty when this is 'false'.
           default: false
@@ -87,7 +87,7 @@ output:
       type: file
       description: |
         IIT GM Desikan parcellation atlas, in the atlas' template space.
-        Empty unless `run_gm_roimetrics` is enabled.
+        Empty unless `fetch_gm_desikan` is enabled.
       structure:
         - gm_atlas:
             type: file
@@ -99,7 +99,7 @@ output:
       type: file
       description: |
         JSON Look-Up Table mapping the GM Desikan label indices to region names.
-        Empty unless `run_gm_roimetrics` is enabled.
+        Empty unless `fetch_gm_desikan` is enabled.
       structure:
         - gm_lut:
             type: file

--- a/subworkflows/nf-neuro/atlas_roimetrics/main.nf
+++ b/subworkflows/nf-neuro/atlas_roimetrics/main.nf
@@ -29,10 +29,10 @@ workflow ATLAS_ROIMETRICS {
         if (options.use_atlas_iit) {
             ATLAS_IIT(
                 [
-                    threshold_bundles: options.use_binary_masks ?: false,
+                    threshold_bundles: options.use_binary_masks,
                     atlas_iit_b0: options.atlas_iit_b0,
                     atlas_iit_bundle_masks_dir: options.atlas_iit_bundle_masks_dir,
-                    run_gm_roimetrics: options.run_gm_roimetrics ?: false,
+                    run_gm_roimetrics: options.run_gm_roimetrics,
                     atlas_iit_gm_atlas: options.atlas_iit_gm_atlas,
                     atlas_iit_gm_lut: options.atlas_iit_gm_lut
                 ]
@@ -71,7 +71,7 @@ workflow ATLAS_ROIMETRICS {
         ch_stats_mean = channel.empty()
         ch_stats_std  = channel.empty()
 
-        if (options.run_roi_metrics != false) {
+        if (options.run_roi_metrics) {
             // Input: [meta, [metrics_list], [masks]]
             ch_input_metricsinroi = ch_metrics
                 .join(TRANSFORM_ATLAS_BUNDLES.out.warped_image)
@@ -120,7 +120,7 @@ workflow ATLAS_ROIMETRICS {
             TRANSFORM_GM_ATLAS(ch_transform_gm)
             ch_versions = ch_versions.mix(TRANSFORM_GM_ATLAS.out.versions)
 
-            if (options.run_roi_metrics != false) {
+            if (options.run_roi_metrics) {
                 ch_gm_input = ch_metrics
                     .join(TRANSFORM_GM_ATLAS.out.warped_image)
                     .combine(ATLAS_IIT.out.gm_lut)

--- a/subworkflows/nf-neuro/atlas_roimetrics/main.nf
+++ b/subworkflows/nf-neuro/atlas_roimetrics/main.nf
@@ -1,6 +1,10 @@
 include { REGISTRATION_ANTS as REGISTER_ATLAS_REF } from '../../../modules/nf-neuro/registration/ants/main'
 include { REGISTRATION_ANTSAPPLYTRANSFORMS as TRANSFORM_ATLAS_BUNDLES } from '../../../modules/nf-neuro/registration/antsapplytransforms/main.nf'
+include { REGISTRATION_ANTSAPPLYTRANSFORMS as TRANSFORM_GM_ATLAS } from '../../../modules/nf-neuro/registration/antsapplytransforms/main.nf'
 include { STATS_METRICSINROI     } from '../../../modules/nf-neuro/stats/metricsinroi/main'
+include { STATS_METRICSINROI as STATS_GM_ROIMETRICS } from '../../../modules/nf-neuro/stats/metricsinroi/main'
+include { STATS_ROIVOLUMES as STATS_WM_VOLUMES } from '../../../modules/nf-neuro/stats/roivolumes/main'
+include { STATS_ROIVOLUMES as STATS_GM_VOLUMES } from '../../../modules/nf-neuro/stats/roivolumes/main'
 include { ATLAS_IIT              } from '../../nf-neuro/atlas_iit/main'
 include { UTILS_OPTIONS } from '../utils_options/main'
 
@@ -27,7 +31,10 @@ workflow ATLAS_ROIMETRICS {
                 [
                     threshold_bundles: options.use_binary_masks ?: false,
                     atlas_iit_b0: options.atlas_iit_b0,
-                    atlas_iit_bundle_masks_dir: options.atlas_iit_bundle_masks_dir
+                    atlas_iit_bundle_masks_dir: options.atlas_iit_bundle_masks_dir,
+                    run_gm_roimetrics: options.run_gm_roimetrics ?: false,
+                    atlas_iit_gm_atlas: options.atlas_iit_gm_atlas,
+                    atlas_iit_gm_lut: options.atlas_iit_gm_lut
                 ]
             )
             ch_versions = ch_versions.mix(ATLAS_IIT.out.versions)
@@ -58,7 +65,7 @@ workflow ATLAS_ROIMETRICS {
         ch_versions = ch_versions.mix(TRANSFORM_ATLAS_BUNDLES.out.versions)
 
         //
-        // EXTRACT ROI VOLUME STATISTICS
+        // EXTRACT ROI DIFFUSION METRICS STATISTICS
         //
         // Input: [meta, [metrics_list], [masks]]
         ch_input_metricsinroi = ch_metrics
@@ -71,10 +78,74 @@ workflow ATLAS_ROIMETRICS {
         STATS_METRICSINROI(ch_input_metricsinroi)
         ch_versions = ch_versions.mix(STATS_METRICSINROI.out.versions)
 
+        //
+        // COMPUTE WM BUNDLE VOLUMES (optional)
+        //
+        ch_wm_volumes = channel.empty()
+
+        if (options.run_roi_volumes) {
+            ch_wm_volumes_input = TRANSFORM_ATLAS_BUNDLES.out.warped_image
+                .map { meta, masks -> [meta, masks, []] }
+            STATS_WM_VOLUMES(ch_wm_volumes_input)
+            ch_versions = ch_versions.mix(STATS_WM_VOLUMES.out.versions)
+            ch_wm_volumes = STATS_WM_VOLUMES.out.volumes
+        }
+
+        //
+        // GM DESIKAN PARCELLATION ROI METRICS (IIT Atlas)
+        //
+        ch_gm_stats_json = channel.empty()
+        ch_gm_stats_mean = channel.empty()
+        ch_gm_stats_std  = channel.empty()
+        ch_gm_volumes    = channel.empty()
+
+        if (options.run_gm_roimetrics) {
+            // Reuse the atlas B0 → subject registration transform for the GM atlas
+            ch_transform_gm = ch_subject_reference
+                .join(REGISTER_ATLAS_REF.out.forward_image_transform)
+                .combine(ATLAS_IIT.out.gm_atlas)
+                .map { meta, subject_ref, transform, gm_atlas ->
+                    [meta, gm_atlas, subject_ref, transform]
+                }
+            TRANSFORM_GM_ATLAS(ch_transform_gm)
+            ch_versions = ch_versions.mix(TRANSFORM_GM_ATLAS.out.versions)
+
+            ch_gm_input = ch_metrics
+                .join(TRANSFORM_GM_ATLAS.out.warped_image)
+                .combine(ATLAS_IIT.out.gm_lut)
+                .map { meta, metrics, gm_warped, lut -> [meta, metrics, gm_warped, lut] }
+
+            STATS_GM_ROIMETRICS(ch_gm_input)
+            ch_versions = ch_versions.mix(STATS_GM_ROIMETRICS.out.versions)
+
+            ch_gm_stats_json = STATS_GM_ROIMETRICS.out.stats_json
+            ch_gm_stats_mean = STATS_GM_ROIMETRICS.out.stats_mean
+            ch_gm_stats_std  = STATS_GM_ROIMETRICS.out.stats_std
+
+            //
+            // COMPUTE GM REGION VOLUMES (optional, only when run_roi_volumes also active)
+            //
+            if (options.run_roi_volumes) {
+                ch_gm_volumes_input = TRANSFORM_GM_ATLAS.out.warped_image
+                    .combine(ATLAS_IIT.out.gm_lut)
+                    .map { meta, gm_atlas, lut -> [meta, gm_atlas, lut] }
+                STATS_GM_VOLUMES(ch_gm_volumes_input)
+                ch_versions = ch_versions.mix(STATS_GM_VOLUMES.out.versions)
+                ch_gm_volumes = STATS_GM_VOLUMES.out.volumes
+            }
+        }
+
     emit:
         stats_json        = STATS_METRICSINROI.out.stats_json
         stats_tab_mean    = STATS_METRICSINROI.out.stats_mean
         stats_tab_std     = STATS_METRICSINROI.out.stats_std
+
+        wm_volumes        = ch_wm_volumes
+
+        gm_stats_json     = ch_gm_stats_json
+        gm_stats_tab_mean = ch_gm_stats_mean
+        gm_stats_tab_std  = ch_gm_stats_std
+        gm_volumes        = ch_gm_volumes
 
         versions        = ch_versions
 }

--- a/subworkflows/nf-neuro/atlas_roimetrics/main.nf
+++ b/subworkflows/nf-neuro/atlas_roimetrics/main.nf
@@ -65,18 +65,28 @@ workflow ATLAS_ROIMETRICS {
         ch_versions = ch_versions.mix(TRANSFORM_ATLAS_BUNDLES.out.versions)
 
         //
-        // EXTRACT ROI DIFFUSION METRICS STATISTICS
+        // EXTRACT ROI DIFFUSION METRICS STATISTICS (optional, default: true)
         //
-        // Input: [meta, [metrics_list], [masks]]
-        ch_input_metricsinroi = ch_metrics
-            .join(TRANSFORM_ATLAS_BUNDLES.out.warped_image)
-            .map {
-                meta, metrics, masks ->
-                    [meta, metrics, masks, []]
-            }
+        ch_stats_json = channel.empty()
+        ch_stats_mean = channel.empty()
+        ch_stats_std  = channel.empty()
 
-        STATS_METRICSINROI(ch_input_metricsinroi)
-        ch_versions = ch_versions.mix(STATS_METRICSINROI.out.versions)
+        if (options.run_roi_metrics != false) {
+            // Input: [meta, [metrics_list], [masks]]
+            ch_input_metricsinroi = ch_metrics
+                .join(TRANSFORM_ATLAS_BUNDLES.out.warped_image)
+                .map {
+                    meta, metrics, masks ->
+                        [meta, metrics, masks, []]
+                }
+
+            STATS_METRICSINROI(ch_input_metricsinroi)
+            ch_versions = ch_versions.mix(STATS_METRICSINROI.out.versions)
+
+            ch_stats_json = STATS_METRICSINROI.out.stats_json
+            ch_stats_mean = STATS_METRICSINROI.out.stats_mean
+            ch_stats_std  = STATS_METRICSINROI.out.stats_std
+        }
 
         //
         // COMPUTE WM BUNDLE VOLUMES (optional)
@@ -110,17 +120,19 @@ workflow ATLAS_ROIMETRICS {
             TRANSFORM_GM_ATLAS(ch_transform_gm)
             ch_versions = ch_versions.mix(TRANSFORM_GM_ATLAS.out.versions)
 
-            ch_gm_input = ch_metrics
-                .join(TRANSFORM_GM_ATLAS.out.warped_image)
-                .combine(ATLAS_IIT.out.gm_lut)
-                .map { meta, metrics, gm_warped, lut -> [meta, metrics, gm_warped, lut] }
+            if (options.run_roi_metrics != false) {
+                ch_gm_input = ch_metrics
+                    .join(TRANSFORM_GM_ATLAS.out.warped_image)
+                    .combine(ATLAS_IIT.out.gm_lut)
+                    .map { meta, metrics, gm_warped, lut -> [meta, metrics, gm_warped, lut] }
 
-            STATS_GM_ROIMETRICS(ch_gm_input)
-            ch_versions = ch_versions.mix(STATS_GM_ROIMETRICS.out.versions)
+                STATS_GM_ROIMETRICS(ch_gm_input)
+                ch_versions = ch_versions.mix(STATS_GM_ROIMETRICS.out.versions)
 
-            ch_gm_stats_json = STATS_GM_ROIMETRICS.out.stats_json
-            ch_gm_stats_mean = STATS_GM_ROIMETRICS.out.stats_mean
-            ch_gm_stats_std  = STATS_GM_ROIMETRICS.out.stats_std
+                ch_gm_stats_json = STATS_GM_ROIMETRICS.out.stats_json
+                ch_gm_stats_mean = STATS_GM_ROIMETRICS.out.stats_mean
+                ch_gm_stats_std  = STATS_GM_ROIMETRICS.out.stats_std
+            }
 
             //
             // COMPUTE GM REGION VOLUMES (optional, only when run_roi_volumes also active)
@@ -136,9 +148,9 @@ workflow ATLAS_ROIMETRICS {
         }
 
     emit:
-        stats_json        = STATS_METRICSINROI.out.stats_json
-        stats_tab_mean    = STATS_METRICSINROI.out.stats_mean
-        stats_tab_std     = STATS_METRICSINROI.out.stats_std
+        stats_json        = ch_stats_json
+        stats_tab_mean    = ch_stats_mean
+        stats_tab_std     = ch_stats_std
 
         wm_volumes        = ch_wm_volumes
 

--- a/subworkflows/nf-neuro/atlas_roimetrics/main.nf
+++ b/subworkflows/nf-neuro/atlas_roimetrics/main.nf
@@ -53,7 +53,7 @@ workflow ATLAS_ROIMETRICS {
                     threshold_bundles: options.use_binary_masks,
                     atlas_iit_b0: options.atlas_iit_b0,
                     atlas_iit_bundle_masks_dir: options.atlas_iit_bundle_masks_dir,
-                    run_gm_roimetrics: want_labelmap,
+                    fetch_gm_desikan: want_labelmap,
                     atlas_iit_gm_atlas: options.atlas_iit_gm_atlas,
                     atlas_iit_gm_lut: options.atlas_iit_gm_lut
                 ]

--- a/subworkflows/nf-neuro/atlas_roimetrics/main.nf
+++ b/subworkflows/nf-neuro/atlas_roimetrics/main.nf
@@ -12,19 +12,23 @@ workflow ATLAS_ROIMETRICS {
     take:
         ch_subject_reference  // channel : [required] meta, subject_ref_image
         ch_metrics            // channel : [required] meta, [metrics]
+        ch_registered_atlas   // channel : [optional] meta, [rois], labelmap, labelmap_lut
         options               // channel : [optional] map of options
 
     main:
         ch_versions = channel.empty()
-        ch_bundle_masks = channel.empty()
-        ch_template_ref = channel.empty()
 
         UTILS_OPTIONS("${moduleDir}/meta.yml", options, true)
         options = UTILS_OPTIONS.out.options.value
 
-        assert [options.use_atlas_iit].count(true) <= 1 :
-            "Only one atlas can be selected at a time for ROI metrics extraction." +
-            " Please set only one of the options 'use_atlas_*' to 'true'."
+        assert [options.use_atlas_iit, options.use_registered_atlas].count(true) <= 1 :
+            "Only one atlas source can be selected at a time for ROI metrics extraction." +
+            " Please set only one of the options 'use_atlas_*' or 'use_registered_atlas' to 'true'."
+
+        // ROIs in the subject's own space, whatever their provenance. Both branches below
+        // must populate these before the statistics section runs.
+        ch_rois_subject_space = channel.empty()  // [meta, [rois]]
+        ch_labelmap_with_lut  = channel.empty()  // [meta, labelmap, lut]
 
         if (options.use_atlas_iit) {
             ATLAS_IIT(
@@ -38,31 +42,60 @@ workflow ATLAS_ROIMETRICS {
                 ]
             )
             ch_versions = ch_versions.mix(ATLAS_IIT.out.versions)
-            ch_bundle_masks = ATLAS_IIT.out.bundles.toList()
-            ch_template_ref = ATLAS_IIT.out.b0
+            def ch_bundle_masks = ATLAS_IIT.out.bundles.toList()
+            def ch_template_ref = ATLAS_IIT.out.b0
+
+            // Register atlas reference image to subject space
+            ch_input_register_atlas = ch_subject_reference
+                .combine(ch_template_ref)
+                .map{ meta, subject_ref, template_ref -> [meta, subject_ref, template_ref, [], []] }
+            REGISTER_ATLAS_REF(ch_input_register_atlas)
+            ch_versions = ch_versions.mix(REGISTER_ATLAS_REF.out.versions)
+
+            // Apply the transformation to subject space to the bundles
+            ch_atlas_transform_bundles = ch_subject_reference
+                .join(REGISTER_ATLAS_REF.out.forward_image_transform)
+                .combine(ch_bundle_masks)
+                .map {
+                    meta, subject_ref, transform, bundles ->
+                        [meta, bundles, subject_ref, transform]
+                }
+            TRANSFORM_ATLAS_BUNDLES(ch_atlas_transform_bundles)
+            ch_versions = ch_versions.mix(TRANSFORM_ATLAS_BUNDLES.out.versions)
+
+            ch_rois_subject_space = TRANSFORM_ATLAS_BUNDLES.out.warped_image
+
+            if (options.run_gm_roimetrics) {
+                // Reuse the atlas B0 → subject registration transform for the GM atlas
+                ch_transform_gm = ch_subject_reference
+                    .join(REGISTER_ATLAS_REF.out.forward_image_transform)
+                    .combine(ATLAS_IIT.out.gm_atlas)
+                    .map { meta, subject_ref, transform, gm_atlas ->
+                        [meta, gm_atlas, subject_ref, transform]
+                    }
+                TRANSFORM_GM_ATLAS(ch_transform_gm)
+                ch_versions = ch_versions.mix(TRANSFORM_GM_ATLAS.out.versions)
+
+                ch_labelmap_with_lut = TRANSFORM_GM_ATLAS.out.warped_image
+                    .combine(ATLAS_IIT.out.gm_lut)
+            }
+        }
+        else if (options.use_registered_atlas) {
+            // The caller registered the atlas itself, so no download and no registration
+            // happen here. Entries are already in each subject's space.
+            ch_rois_subject_space = ch_registered_atlas
+                .map { meta, rois, _labelmap, _lut -> [meta, rois] }
+                .filter { _meta, rois -> rois }
+
+            ch_labelmap_with_lut = ch_registered_atlas
+                .filter { _meta, _rois, labelmap, lut -> labelmap && lut }
+                .map { meta, _rois, labelmap, lut -> [meta, labelmap, lut] }
         }
         else {
             error "No atlas selected for ROI metrics extraction. " +
-                "Please set one of the options 'use_atlas_*' to 'true' to run atlas-based ROI metrics."
+                "Please set one of the options 'use_atlas_*' to 'true' to run atlas-based ROI metrics, " +
+                "or set 'use_registered_atlas' to 'true' and supply the atlas through 'ch_registered_atlas'."
         }
-
-        // Register atlas reference image to subject space
-        ch_input_register_atlas = ch_subject_reference
-            .combine(ch_template_ref)
-            .map{ meta, subject_ref, template_ref -> [meta, subject_ref, template_ref, [], []] }
-        REGISTER_ATLAS_REF(ch_input_register_atlas)
-        ch_versions = ch_versions.mix(REGISTER_ATLAS_REF.out.versions)
-
-        // Apply the transformation to subject space to the bundles
-        ch_atlas_transform_bundles = ch_subject_reference
-            .join(REGISTER_ATLAS_REF.out.forward_image_transform)
-            .combine(ch_bundle_masks)
-            .map {
-                meta, subject_ref, transform, bundles ->
-                    [meta, bundles, subject_ref, transform]
-            }
-        TRANSFORM_ATLAS_BUNDLES(ch_atlas_transform_bundles)
-        ch_versions = ch_versions.mix(TRANSFORM_ATLAS_BUNDLES.out.versions)
 
         //
         // EXTRACT ROI DIFFUSION METRICS STATISTICS (optional, default: true)
@@ -74,7 +107,7 @@ workflow ATLAS_ROIMETRICS {
         if (options.run_roi_metrics) {
             // Input: [meta, [metrics_list], [masks]]
             ch_input_metricsinroi = ch_metrics
-                .join(TRANSFORM_ATLAS_BUNDLES.out.warped_image)
+                .join(ch_rois_subject_space)
                 .map {
                     meta, metrics, masks ->
                         [meta, metrics, masks, []]
@@ -94,7 +127,7 @@ workflow ATLAS_ROIMETRICS {
         ch_wm_volumes = channel.empty()
 
         if (options.run_roi_volumes) {
-            ch_wm_volumes_input = TRANSFORM_ATLAS_BUNDLES.out.warped_image
+            ch_wm_volumes_input = ch_rois_subject_space
                 .map { meta, masks -> [meta, masks, []] }
             STATS_WM_VOLUMES(ch_wm_volumes_input)
             ch_versions = ch_versions.mix(STATS_WM_VOLUMES.out.versions)
@@ -102,29 +135,20 @@ workflow ATLAS_ROIMETRICS {
         }
 
         //
-        // GM DESIKAN PARCELLATION ROI METRICS (IIT Atlas)
+        // LABELMAP ROI METRICS — the GM Desikan parcellation under the IIT atlas, or
+        // whatever labelmap the caller supplied through ch_registered_atlas. When no
+        // labelmap is available ch_labelmap_with_lut stays empty and nothing runs.
         //
         ch_gm_stats_json = channel.empty()
         ch_gm_stats_mean = channel.empty()
         ch_gm_stats_std  = channel.empty()
         ch_gm_volumes    = channel.empty()
 
-        if (options.run_gm_roimetrics) {
-            // Reuse the atlas B0 → subject registration transform for the GM atlas
-            ch_transform_gm = ch_subject_reference
-                .join(REGISTER_ATLAS_REF.out.forward_image_transform)
-                .combine(ATLAS_IIT.out.gm_atlas)
-                .map { meta, subject_ref, transform, gm_atlas ->
-                    [meta, gm_atlas, subject_ref, transform]
-                }
-            TRANSFORM_GM_ATLAS(ch_transform_gm)
-            ch_versions = ch_versions.mix(TRANSFORM_GM_ATLAS.out.versions)
-
+        if (options.run_gm_roimetrics || options.use_registered_atlas) {
             if (options.run_roi_metrics) {
                 ch_gm_input = ch_metrics
-                    .join(TRANSFORM_GM_ATLAS.out.warped_image)
-                    .combine(ATLAS_IIT.out.gm_lut)
-                    .map { meta, metrics, gm_warped, lut -> [meta, metrics, gm_warped, lut] }
+                    .join(ch_labelmap_with_lut)
+                    .map { meta, metrics, labelmap, lut -> [meta, metrics, labelmap, lut] }
 
                 STATS_GM_ROIMETRICS(ch_gm_input)
                 ch_versions = ch_versions.mix(STATS_GM_ROIMETRICS.out.versions)
@@ -135,13 +159,10 @@ workflow ATLAS_ROIMETRICS {
             }
 
             //
-            // COMPUTE GM REGION VOLUMES (optional, only when run_roi_volumes also active)
+            // COMPUTE LABELMAP REGION VOLUMES (optional, only when run_roi_volumes also active)
             //
             if (options.run_roi_volumes) {
-                ch_gm_volumes_input = TRANSFORM_GM_ATLAS.out.warped_image
-                    .combine(ATLAS_IIT.out.gm_lut)
-                    .map { meta, gm_atlas, lut -> [meta, gm_atlas, lut] }
-                STATS_GM_VOLUMES(ch_gm_volumes_input)
+                STATS_GM_VOLUMES(ch_labelmap_with_lut)
                 ch_versions = ch_versions.mix(STATS_GM_VOLUMES.out.versions)
                 ch_gm_volumes = STATS_GM_VOLUMES.out.volumes
             }

--- a/subworkflows/nf-neuro/atlas_roimetrics/main.nf
+++ b/subworkflows/nf-neuro/atlas_roimetrics/main.nf
@@ -1,10 +1,10 @@
-include { REGISTRATION_ANTS as REGISTER_ATLAS_REF } from '../../../modules/nf-neuro/registration/ants/main'
-include { REGISTRATION_ANTSAPPLYTRANSFORMS as TRANSFORM_ATLAS_BUNDLES } from '../../../modules/nf-neuro/registration/antsapplytransforms/main.nf'
-include { REGISTRATION_ANTSAPPLYTRANSFORMS as TRANSFORM_GM_ATLAS } from '../../../modules/nf-neuro/registration/antsapplytransforms/main.nf'
-include { STATS_METRICSINROI     } from '../../../modules/nf-neuro/stats/metricsinroi/main'
-include { STATS_METRICSINROI as STATS_GM_ROIMETRICS } from '../../../modules/nf-neuro/stats/metricsinroi/main'
-include { STATS_ROIVOLUMES as STATS_WM_VOLUMES } from '../../../modules/nf-neuro/stats/roivolumes/main'
-include { STATS_ROIVOLUMES as STATS_GM_VOLUMES } from '../../../modules/nf-neuro/stats/roivolumes/main'
+include { REGISTRATION_ANTS as REGISTER_IIT_REF } from '../../../modules/nf-neuro/registration/ants/main'
+include { REGISTRATION_ANTSAPPLYTRANSFORMS as TRANSFORM_IIT_BUNDLES } from '../../../modules/nf-neuro/registration/antsapplytransforms/main.nf'
+include { REGISTRATION_ANTSAPPLYTRANSFORMS as TRANSFORM_IIT_GM_ATLAS } from '../../../modules/nf-neuro/registration/antsapplytransforms/main.nf'
+include { STATS_METRICSINROI as STATS_MASK_METRICS } from '../../../modules/nf-neuro/stats/metricsinroi/main'
+include { STATS_METRICSINROI as STATS_LABELMAP_METRICS } from '../../../modules/nf-neuro/stats/metricsinroi/main'
+include { STATS_ROIVOLUMES as STATS_MASK_VOLUMES } from '../../../modules/nf-neuro/stats/roivolumes/main'
+include { STATS_ROIVOLUMES as STATS_LABELMAP_VOLUMES } from '../../../modules/nf-neuro/stats/roivolumes/main'
 include { ATLAS_IIT              } from '../../nf-neuro/atlas_iit/main'
 include { UTILS_OPTIONS } from '../utils_options/main'
 
@@ -25,10 +25,27 @@ workflow ATLAS_ROIMETRICS {
             "Only one atlas source can be selected at a time for ROI metrics extraction." +
             " Please set only one of the options 'use_atlas_*' or 'use_registered_atlas' to 'true'."
 
+        // What the ROIs look like, and what to compute on them. The two axes are
+        // independent: any combination of sources and outputs is valid.
+        def roi_sources = options.roi_sources instanceof List ? options.roi_sources : [options.roi_sources]
+        def roi_outputs = options.roi_outputs instanceof List ? options.roi_outputs : [options.roi_outputs]
+
+        assert roi_sources && roi_sources.every { it in ["masks", "labelmap"] } :
+            "Option 'roi_sources' must be a non-empty list holding 'masks', 'labelmap' or both," +
+            " but got '${options.roi_sources}'."
+        assert roi_outputs && roi_outputs.every { it in ["metrics", "volumes"] } :
+            "Option 'roi_outputs' must be a non-empty list holding 'metrics', 'volumes' or both," +
+            " but got '${options.roi_outputs}'."
+
+        def want_masks    = "masks" in roi_sources
+        def want_labelmap = "labelmap" in roi_sources
+        def want_metrics  = "metrics" in roi_outputs
+        def want_volumes  = "volumes" in roi_outputs
+
         // ROIs in the subject's own space, whatever their provenance. Both branches below
         // must populate these before the statistics section runs.
-        ch_rois_subject_space = channel.empty()  // [meta, [rois]]
-        ch_labelmap_with_lut  = channel.empty()  // [meta, labelmap, lut]
+        ch_masks_subject_space = channel.empty()  // [meta, [masks]]
+        ch_labelmap_with_lut   = channel.empty()  // [meta, labelmap, lut]
 
         if (options.use_atlas_iit) {
             ATLAS_IIT(
@@ -36,60 +53,64 @@ workflow ATLAS_ROIMETRICS {
                     threshold_bundles: options.use_binary_masks,
                     atlas_iit_b0: options.atlas_iit_b0,
                     atlas_iit_bundle_masks_dir: options.atlas_iit_bundle_masks_dir,
-                    run_gm_roimetrics: options.run_gm_roimetrics,
+                    run_gm_roimetrics: want_labelmap,
                     atlas_iit_gm_atlas: options.atlas_iit_gm_atlas,
                     atlas_iit_gm_lut: options.atlas_iit_gm_lut
                 ]
             )
             ch_versions = ch_versions.mix(ATLAS_IIT.out.versions)
-            def ch_bundle_masks = ATLAS_IIT.out.bundles.toList()
-            def ch_template_ref = ATLAS_IIT.out.b0
 
-            // Register atlas reference image to subject space
+            // Register the atlas reference image to subject space. Both transforms below
+            // reuse this single registration.
             ch_input_register_atlas = ch_subject_reference
-                .combine(ch_template_ref)
+                .combine(ATLAS_IIT.out.b0)
                 .map{ meta, subject_ref, template_ref -> [meta, subject_ref, template_ref, [], []] }
-            REGISTER_ATLAS_REF(ch_input_register_atlas)
-            ch_versions = ch_versions.mix(REGISTER_ATLAS_REF.out.versions)
+            REGISTER_IIT_REF(ch_input_register_atlas)
+            ch_versions = ch_versions.mix(REGISTER_IIT_REF.out.versions)
 
-            // Apply the transformation to subject space to the bundles
-            ch_atlas_transform_bundles = ch_subject_reference
-                .join(REGISTER_ATLAS_REF.out.forward_image_transform)
-                .combine(ch_bundle_masks)
-                .map {
-                    meta, subject_ref, transform, bundles ->
-                        [meta, bundles, subject_ref, transform]
-                }
-            TRANSFORM_ATLAS_BUNDLES(ch_atlas_transform_bundles)
-            ch_versions = ch_versions.mix(TRANSFORM_ATLAS_BUNDLES.out.versions)
+            if (want_masks) {
+                // Apply the transformation to subject space to the bundle masks
+                ch_atlas_transform_bundles = ch_subject_reference
+                    .join(REGISTER_IIT_REF.out.forward_image_transform)
+                    .combine(ATLAS_IIT.out.bundles.toList())
+                    .map {
+                        meta, subject_ref, transform, bundles ->
+                            [meta, bundles, subject_ref, transform]
+                    }
+                TRANSFORM_IIT_BUNDLES(ch_atlas_transform_bundles)
+                ch_versions = ch_versions.mix(TRANSFORM_IIT_BUNDLES.out.versions)
 
-            ch_rois_subject_space = TRANSFORM_ATLAS_BUNDLES.out.warped_image
+                ch_masks_subject_space = TRANSFORM_IIT_BUNDLES.out.warped_image
+            }
 
-            if (options.run_gm_roimetrics) {
-                // Reuse the atlas B0 → subject registration transform for the GM atlas
+            if (want_labelmap) {
                 ch_transform_gm = ch_subject_reference
-                    .join(REGISTER_ATLAS_REF.out.forward_image_transform)
+                    .join(REGISTER_IIT_REF.out.forward_image_transform)
                     .combine(ATLAS_IIT.out.gm_atlas)
                     .map { meta, subject_ref, transform, gm_atlas ->
                         [meta, gm_atlas, subject_ref, transform]
                     }
-                TRANSFORM_GM_ATLAS(ch_transform_gm)
-                ch_versions = ch_versions.mix(TRANSFORM_GM_ATLAS.out.versions)
+                TRANSFORM_IIT_GM_ATLAS(ch_transform_gm)
+                ch_versions = ch_versions.mix(TRANSFORM_IIT_GM_ATLAS.out.versions)
 
-                ch_labelmap_with_lut = TRANSFORM_GM_ATLAS.out.warped_image
+                ch_labelmap_with_lut = TRANSFORM_IIT_GM_ATLAS.out.warped_image
                     .combine(ATLAS_IIT.out.gm_lut)
             }
         }
         else if (options.use_registered_atlas) {
             // The caller registered the atlas itself, so no download and no registration
             // happen here. Entries are already in each subject's space.
-            ch_rois_subject_space = ch_registered_atlas
-                .map { meta, rois, _labelmap, _lut -> [meta, rois] }
-                .filter { _meta, rois -> rois }
+            if (want_masks) {
+                ch_masks_subject_space = ch_registered_atlas
+                    .map { meta, masks, _labelmap, _lut -> [meta, masks] }
+                    .filter { _meta, masks -> masks }
+            }
 
-            ch_labelmap_with_lut = ch_registered_atlas
-                .filter { _meta, _rois, labelmap, lut -> labelmap && lut }
-                .map { meta, _rois, labelmap, lut -> [meta, labelmap, lut] }
+            if (want_labelmap) {
+                ch_labelmap_with_lut = ch_registered_atlas
+                    .filter { _meta, _masks, labelmap, lut -> labelmap && lut }
+                    .map { meta, _masks, labelmap, lut -> [meta, labelmap, lut] }
+            }
         }
         else {
             error "No atlas selected for ROI metrics extraction. " +
@@ -98,87 +119,77 @@ workflow ATLAS_ROIMETRICS {
         }
 
         //
-        // EXTRACT ROI DIFFUSION METRICS STATISTICS (optional, default: true)
+        // STATISTICS OVER INDIVIDUAL ROI MASKS ('masks' source)
         //
-        ch_stats_json = channel.empty()
-        ch_stats_mean = channel.empty()
-        ch_stats_std  = channel.empty()
+        ch_mask_stats_json = channel.empty()
+        ch_mask_stats_mean = channel.empty()
+        ch_mask_stats_std  = channel.empty()
+        ch_mask_volumes    = channel.empty()
 
-        if (options.run_roi_metrics) {
+        if (want_masks && want_metrics) {
             // Input: [meta, [metrics_list], [masks]]
-            ch_input_metricsinroi = ch_metrics
-                .join(ch_rois_subject_space)
+            ch_input_mask_metrics = ch_metrics
+                .join(ch_masks_subject_space)
                 .map {
                     meta, metrics, masks ->
                         [meta, metrics, masks, []]
                 }
 
-            STATS_METRICSINROI(ch_input_metricsinroi)
-            ch_versions = ch_versions.mix(STATS_METRICSINROI.out.versions)
+            STATS_MASK_METRICS(ch_input_mask_metrics)
+            ch_versions = ch_versions.mix(STATS_MASK_METRICS.out.versions)
 
-            ch_stats_json = STATS_METRICSINROI.out.stats_json
-            ch_stats_mean = STATS_METRICSINROI.out.stats_mean
-            ch_stats_std  = STATS_METRICSINROI.out.stats_std
+            ch_mask_stats_json = STATS_MASK_METRICS.out.stats_json
+            ch_mask_stats_mean = STATS_MASK_METRICS.out.stats_mean
+            ch_mask_stats_std  = STATS_MASK_METRICS.out.stats_std
         }
 
-        //
-        // COMPUTE WM BUNDLE VOLUMES (optional)
-        //
-        ch_wm_volumes = channel.empty()
-
-        if (options.run_roi_volumes) {
-            ch_wm_volumes_input = ch_rois_subject_space
+        if (want_masks && want_volumes) {
+            ch_mask_volumes_input = ch_masks_subject_space
                 .map { meta, masks -> [meta, masks, []] }
-            STATS_WM_VOLUMES(ch_wm_volumes_input)
-            ch_versions = ch_versions.mix(STATS_WM_VOLUMES.out.versions)
-            ch_wm_volumes = STATS_WM_VOLUMES.out.volumes
+            STATS_MASK_VOLUMES(ch_mask_volumes_input)
+            ch_versions = ch_versions.mix(STATS_MASK_VOLUMES.out.versions)
+            ch_mask_volumes = STATS_MASK_VOLUMES.out.volumes
         }
 
         //
-        // LABELMAP ROI METRICS — the GM Desikan parcellation under the IIT atlas, or
-        // whatever labelmap the caller supplied through ch_registered_atlas. When no
-        // labelmap is available ch_labelmap_with_lut stays empty and nothing runs.
+        // STATISTICS OVER A LABELMAP ('labelmap' source) — the IIT GM Desikan
+        // parcellation under 'use_atlas_iit', or whatever labelmap the caller
+        // supplied through 'ch_registered_atlas'.
         //
-        ch_gm_stats_json = channel.empty()
-        ch_gm_stats_mean = channel.empty()
-        ch_gm_stats_std  = channel.empty()
-        ch_gm_volumes    = channel.empty()
+        ch_labelmap_stats_json = channel.empty()
+        ch_labelmap_stats_mean = channel.empty()
+        ch_labelmap_stats_std  = channel.empty()
+        ch_labelmap_volumes    = channel.empty()
 
-        if (options.run_gm_roimetrics || options.use_registered_atlas) {
-            if (options.run_roi_metrics) {
-                ch_gm_input = ch_metrics
-                    .join(ch_labelmap_with_lut)
-                    .map { meta, metrics, labelmap, lut -> [meta, metrics, labelmap, lut] }
+        if (want_labelmap && want_metrics) {
+            ch_input_labelmap_metrics = ch_metrics
+                .join(ch_labelmap_with_lut)
+                .map { meta, metrics, labelmap, lut -> [meta, metrics, labelmap, lut] }
 
-                STATS_GM_ROIMETRICS(ch_gm_input)
-                ch_versions = ch_versions.mix(STATS_GM_ROIMETRICS.out.versions)
+            STATS_LABELMAP_METRICS(ch_input_labelmap_metrics)
+            ch_versions = ch_versions.mix(STATS_LABELMAP_METRICS.out.versions)
 
-                ch_gm_stats_json = STATS_GM_ROIMETRICS.out.stats_json
-                ch_gm_stats_mean = STATS_GM_ROIMETRICS.out.stats_mean
-                ch_gm_stats_std  = STATS_GM_ROIMETRICS.out.stats_std
-            }
+            ch_labelmap_stats_json = STATS_LABELMAP_METRICS.out.stats_json
+            ch_labelmap_stats_mean = STATS_LABELMAP_METRICS.out.stats_mean
+            ch_labelmap_stats_std  = STATS_LABELMAP_METRICS.out.stats_std
+        }
 
-            //
-            // COMPUTE LABELMAP REGION VOLUMES (optional, only when run_roi_volumes also active)
-            //
-            if (options.run_roi_volumes) {
-                STATS_GM_VOLUMES(ch_labelmap_with_lut)
-                ch_versions = ch_versions.mix(STATS_GM_VOLUMES.out.versions)
-                ch_gm_volumes = STATS_GM_VOLUMES.out.volumes
-            }
+        if (want_labelmap && want_volumes) {
+            STATS_LABELMAP_VOLUMES(ch_labelmap_with_lut)
+            ch_versions = ch_versions.mix(STATS_LABELMAP_VOLUMES.out.versions)
+            ch_labelmap_volumes = STATS_LABELMAP_VOLUMES.out.volumes
         }
 
     emit:
-        stats_json        = ch_stats_json
-        stats_tab_mean    = ch_stats_mean
-        stats_tab_std     = ch_stats_std
+        mask_stats_json         = ch_mask_stats_json
+        mask_stats_tab_mean     = ch_mask_stats_mean
+        mask_stats_tab_std      = ch_mask_stats_std
+        mask_volumes            = ch_mask_volumes
 
-        wm_volumes        = ch_wm_volumes
+        labelmap_stats_json     = ch_labelmap_stats_json
+        labelmap_stats_tab_mean = ch_labelmap_stats_mean
+        labelmap_stats_tab_std  = ch_labelmap_stats_std
+        labelmap_volumes        = ch_labelmap_volumes
 
-        gm_stats_json     = ch_gm_stats_json
-        gm_stats_tab_mean = ch_gm_stats_mean
-        gm_stats_tab_std  = ch_gm_stats_std
-        gm_volumes        = ch_gm_volumes
-
-        versions        = ch_versions
+        versions                = ch_versions
 }

--- a/subworkflows/nf-neuro/atlas_roimetrics/meta.yml
+++ b/subworkflows/nf-neuro/atlas_roimetrics/meta.yml
@@ -56,6 +56,46 @@ input:
       pattern: "*.nii.gz"
       ontologies:
         - edam: http://edamontology.org/format_4001 # NIFTI format
+  - ch_registered_atlas:
+      type: file
+      description: |
+        Atlas already registered into each subject's space, supplied by the caller instead of
+        being downloaded and registered by this subworkflow. Only read when
+        `use_registered_atlas` is 'true'; pass `channel.empty()` otherwise.
+
+        Each entry carries both possible ROI representations, and either may be empty:
+        a list of individual ROI mask files, and a single labelmap image paired with its
+        Look-Up Table. Entries whose mask list is empty are skipped for the mask-based
+        statistics, and entries missing either the labelmap or the LUT are skipped for the
+        labelmap-based statistics.
+
+        Supplying this instead of `use_atlas_iit` lets the caller choose its own registration
+        strategy, reuse a transform computed earlier in the pipeline, or work from an atlas
+        this subworkflow does not know how to fetch.
+      structure:
+        - meta:
+            type: map
+            description: Metadata map.
+        - rois:
+            type: file
+            description: |
+              List of ROI mask files in the subject's space, one file per ROI. Pass [] to
+              compute labelmap statistics only.
+        - labelmap:
+            type: file
+            description: |
+              Single labelmap image in the subject's space, whose integer voxel values
+              identify regions. Pass [] to compute mask statistics only.
+        - labelmap_lut:
+            type: file
+            description: |
+              JSON Look-Up Table mapping the labelmap's integer indices to region names.
+              Required whenever `labelmap` is provided.
+      pattern: "*.{nii.gz,json}"
+      mandatory: false
+      ontologies:
+        - edam: http://edamontology.org/format_4001 # NIFTI format
+        - edam: http://edamontology.org/format_3464 # JSON format
   - options:
       type: map
       description: Map of options for the subworkflow.
@@ -63,6 +103,13 @@ input:
         use_atlas_iit:
           type: boolean
           description: If 'true', the IIT Human Brain Atlas will be used for ROI metrics extraction.
+          default: false
+        use_registered_atlas:
+          type: boolean
+          description: |
+            If 'true', the atlas is taken from the `ch_registered_atlas` input, already in each
+            subject's space. No atlas is downloaded and no registration is performed. Mutually
+            exclusive with `use_atlas_iit`; exactly one of the two must be enabled.
           default: false
         atlas_iit_b0:
           type: string
@@ -145,8 +192,10 @@ output:
   - wm_volumes:
       type: file
       description: |
-        CSV holding the voxel count and volume (mm3) of each WM bundle mask,
-        in the subject's DWI space. Empty unless `run_roi_volumes` is enabled.
+        CSV holding the voxel count and volume (mm3) of each individual ROI mask,
+        in the subject's DWI space — the IIT WM bundles under `use_atlas_iit`, or the
+        masks supplied through `ch_registered_atlas` under `use_registered_atlas`.
+        Empty unless `run_roi_volumes` is enabled.
       structure:
         - meta:
             type: map
@@ -204,9 +253,11 @@ output:
   - gm_volumes:
       type: file
       description: |
-        CSV holding the voxel count and volume (mm3) of each GM Desikan region,
-        in the subject's DWI space. Empty unless both `run_gm_roimetrics` and
-        `run_roi_volumes` are enabled.
+        CSV holding the voxel count and volume (mm3) of each labelmap region, in the
+        subject's DWI space — the GM Desikan regions under `use_atlas_iit`, or the
+        regions of the labelmap supplied through `ch_registered_atlas` under
+        `use_registered_atlas`. Empty unless `run_roi_volumes` is enabled, and — with
+        the IIT atlas — `run_gm_roimetrics` as well.
       structure:
         - meta:
             type: map

--- a/subworkflows/nf-neuro/atlas_roimetrics/meta.yml
+++ b/subworkflows/nf-neuro/atlas_roimetrics/meta.yml
@@ -75,6 +75,18 @@ input:
           type: boolean
           description: If 'true', the IIT bundle masks will be thresholded to create binary masks before extracting the metrics.
           default: false
+        run_gm_roimetrics:
+          type: boolean
+          description: If 'true', also extract metrics per IIT GM Desikan parcellation region, reusing the WM atlas B0 registration.
+          default: false
+        run_roi_volumes:
+          type: boolean
+          description: If 'true', compute voxel count and volume (mm3) for each WM bundle mask and GM region using mrstats.
+          default: false
+        run_roi_metrics:
+          type: boolean
+          description: If 'false', skip STATS_METRICSINROI and STATS_GM_ROIMETRICS (diffusion metric extraction). Useful when only volumes are needed. Defaults to true.
+          default: true
       mandatory: true
 output:
   - json:

--- a/subworkflows/nf-neuro/atlas_roimetrics/meta.yml
+++ b/subworkflows/nf-neuro/atlas_roimetrics/meta.yml
@@ -20,6 +20,7 @@ components:
   - atlas_iit
   - registration/ants
   - stats/metricsinroi
+  - stats/roivolumes
   - registration/antsapplytransforms
   - utils_options
 input:
@@ -79,9 +80,17 @@ input:
           type: boolean
           description: If 'true', also extract metrics per IIT GM Desikan parcellation region, reusing the WM atlas B0 registration.
           default: false
+        atlas_iit_gm_atlas:
+          type: string
+          description: Path to the IIT GM Desikan atlas (IIT_GM_Desikan_atlas.nii.gz). This input will be used instead of downloading the atlas if `run_gm_roimetrics` is set to 'true'.
+          default: null
+        atlas_iit_gm_lut:
+          type: string
+          description: Path to the IIT GM Desikan Look-Up Table. Accepts either a pre-converted JSON file or the raw tab-separated TXT distributed by NITRC (LUT_GM_Desikan_0to1.txt). This input will be used instead of downloading the LUT if `run_gm_roimetrics` is set to 'true'.
+          default: null
         run_roi_volumes:
           type: boolean
-          description: If 'true', compute voxel count and volume (mm3) for each WM bundle mask and GM region using mrstats.
+          description: If 'true', compute voxel count and volume (mm3) for each WM bundle mask and GM region using stats/roivolumes.
           default: false
         run_roi_metrics:
           type: boolean
@@ -89,19 +98,19 @@ input:
           default: true
       mandatory: true
 output:
-  - json:
+  - stats_json:
       type: file
-      description: List of binary bundle masks.
+      description: Per-bundle metrics statistics, as JSON.
       structure:
         - meta:
             type: map
             description: Metadata map.
-        - img:
+        - stats_json:
             type: file
-            description: List of binary bundle masks in the subject's DWI space.
-      pattern: "*.nii.gz"
+            description: JSON statistics file for the WM bundle masks.
+      pattern: "*.json"
       ontologies:
-        - edam: http://edamontology.org/format_4001 # NIFTI format
+        - edam: http://edamontology.org/format_3464 # JSON format
   - stats_tab_mean:
       type: file
       description: |
@@ -133,6 +142,81 @@ output:
             description: Standard deviation statistics table file.
       pattern: "*_desc-std_*.{csv,tsv}"
       ontologies: []
+  - wm_volumes:
+      type: file
+      description: |
+        CSV holding the voxel count and volume (mm3) of each WM bundle mask,
+        in the subject's DWI space. Empty unless `run_roi_volumes` is enabled.
+      structure:
+        - meta:
+            type: map
+            description: Metadata map.
+        - wm_volumes:
+            type: file
+            description: WM bundle volumes table.
+      pattern: "*_volumes.csv"
+      ontologies:
+        - edam: http://edamontology.org/format_3752 # CSV format
+  - gm_stats_json:
+      type: file
+      description: |
+        Per-region GM metrics statistics, as JSON. Empty unless
+        `run_gm_roimetrics` is enabled.
+      structure:
+        - meta:
+            type: map
+            description: Metadata map.
+        - gm_stats_json:
+            type: file
+            description: JSON statistics file for the GM Desikan regions.
+      pattern: "*.json"
+      ontologies:
+        - edam: http://edamontology.org/format_3464 # JSON format
+  - gm_stats_tab_mean:
+      type: file
+      description: |
+        Structured tabular (TSV or CSV) file holding MEAN metrics values for
+        each GM Desikan region. Empty unless `run_gm_roimetrics` is enabled.
+      structure:
+        - meta:
+            type: map
+            description: Metadata map.
+        - gm_tab_mean:
+            type: file
+            description: Mean statistics table file for the GM Desikan regions.
+      pattern: "*_desc-mean_*.{csv,tsv}"
+      ontologies: []
+  - gm_stats_tab_std:
+      type: file
+      description: |
+        Structured tabular (TSV or CSV) file holding STANDARD DEVIATION metrics
+        values for each GM Desikan region. Empty unless `run_gm_roimetrics` is
+        enabled.
+      structure:
+        - meta:
+            type: map
+            description: Metadata map.
+        - gm_tab_std:
+            type: file
+            description: Standard deviation statistics table file for the GM Desikan regions.
+      pattern: "*_desc-std_*.{csv,tsv}"
+      ontologies: []
+  - gm_volumes:
+      type: file
+      description: |
+        CSV holding the voxel count and volume (mm3) of each GM Desikan region,
+        in the subject's DWI space. Empty unless both `run_gm_roimetrics` and
+        `run_roi_volumes` are enabled.
+      structure:
+        - meta:
+            type: map
+            description: Metadata map.
+        - gm_volumes:
+            type: file
+            description: GM Desikan region volumes table.
+      pattern: "*_volumes.csv"
+      ontologies:
+        - edam: http://edamontology.org/format_3752 # CSV format
   - versions:
       type: file
       description: |

--- a/subworkflows/nf-neuro/atlas_roimetrics/meta.yml
+++ b/subworkflows/nf-neuro/atlas_roimetrics/meta.yml
@@ -111,6 +111,28 @@ input:
             subject's space. No atlas is downloaded and no registration is performed. Mutually
             exclusive with `use_atlas_iit`; exactly one of the two must be enabled.
           default: false
+        roi_sources:
+          type: list
+          description: |
+            How the ROIs are represented. `masks` means one image file per ROI (the IIT WM
+            bundles, or the mask list of `ch_registered_atlas`); `labelmap` means a single
+            image whose integer voxel values identify regions, paired with a Look-Up Table
+            (the IIT GM Desikan parcellation, or the labelmap of `ch_registered_atlas`).
+
+            Accepts either or both. Only the representations listed here are warped into
+            subject space and fed to the statistics, so leaving one out skips its work
+            entirely. Orthogonal to `roi_outputs`: any combination of the two is valid.
+          default: ["masks"]
+        roi_outputs:
+          type: list
+          description: |
+            What to compute for every representation named in `roi_sources`. `metrics` runs
+            stats/metricsinroi to extract the mean and standard deviation of each input metric
+            map; `volumes` runs stats/roivolumes to count voxels and convert them to mm3.
+
+            Accepts either or both. Orthogonal to `roi_sources`: any combination of the two
+            is valid.
+          default: ["metrics"]
         atlas_iit_b0:
           type: string
           description: Path to a Mean B0 map of the IIT Human Brain Atlas. This input will be used instead of downloading the Mean B0 map if `use_atlas_iit` is set to 'true'.
@@ -123,148 +145,140 @@ input:
           type: boolean
           description: If 'true', the IIT bundle masks will be thresholded to create binary masks before extracting the metrics.
           default: false
-        run_gm_roimetrics:
-          type: boolean
-          description: If 'true', also extract metrics per IIT GM Desikan parcellation region, reusing the WM atlas B0 registration.
-          default: false
         atlas_iit_gm_atlas:
           type: string
-          description: Path to the IIT GM Desikan atlas (IIT_GM_Desikan_atlas.nii.gz). This input will be used instead of downloading the atlas if `run_gm_roimetrics` is set to 'true'.
+          description: Path to the IIT GM Desikan atlas (IIT_GM_Desikan_atlas.nii.gz). This input will be used instead of downloading the atlas when `roi_sources` includes 'labelmap'.
           default: null
         atlas_iit_gm_lut:
           type: string
-          description: Path to the IIT GM Desikan Look-Up Table. Accepts either a pre-converted JSON file or the raw tab-separated TXT distributed by NITRC (LUT_GM_Desikan_0to1.txt). This input will be used instead of downloading the LUT if `run_gm_roimetrics` is set to 'true'.
+          description: Path to the IIT GM Desikan Look-Up Table. Accepts either a pre-converted JSON file or the raw tab-separated TXT distributed by NITRC (LUT_GM_Desikan_0to1.txt). This input will be used instead of downloading the LUT when `roi_sources` includes 'labelmap'.
           default: null
-        run_roi_volumes:
-          type: boolean
-          description: If 'true', compute voxel count and volume (mm3) for each WM bundle mask and GM region using stats/roivolumes.
-          default: false
-        run_roi_metrics:
-          type: boolean
-          description: If 'false', skip STATS_METRICSINROI and STATS_GM_ROIMETRICS (diffusion metric extraction). Useful when only volumes are needed. Defaults to true.
-          default: true
       mandatory: true
 output:
-  - stats_json:
+  - mask_stats_json:
       type: file
-      description: Per-bundle metrics statistics, as JSON.
+      description: |
+        Per-ROI metrics statistics over the individual masks, as JSON. Empty unless
+        `roi_sources` includes 'masks' and `roi_outputs` includes 'metrics'.
       structure:
         - meta:
             type: map
             description: Metadata map.
-        - stats_json:
+        - mask_stats_json:
             type: file
-            description: JSON statistics file for the WM bundle masks.
+            description: JSON statistics file for the individual ROI masks.
       pattern: "*.json"
       ontologies:
         - edam: http://edamontology.org/format_3464 # JSON format
-  - stats_tab_mean:
+  - mask_stats_tab_mean:
       type: file
       description: |
-        Structured tabular (TSV or CSV) file holding MEAN metrics
-        values for each bundle mask. The tabular file has the following
-        column structure: (sample, roi, metric1, metric2, ..., metricN).
+        Structured tabular (TSV or CSV) file holding MEAN metrics values for each
+        individual ROI mask. The tabular file has the following column structure:
+        (sample, roi, metric1, metric2, ..., metricN). Empty unless `roi_sources`
+        includes 'masks' and `roi_outputs` includes 'metrics'.
       structure:
         - meta:
             type: map
             description: Metadata map.
-        - tab_mean:
+        - mask_tab_mean:
             type: file
-            description: Mean statistics table file.
+            description: Mean statistics table file for the individual ROI masks.
       pattern: "*_desc-mean_*.{csv,tsv}"
       ontologies: []
-  - stats_tab_std:
+  - mask_stats_tab_std:
       type: file
       description: |
-        Structured tabular (TSV or CSV) file holding STANDARD
-        DEVIATION metrics values for each bundle mask. The
-        tabular file has the following column structure:
-        (sample, roi, metric1, metric2, ..., metricN).
+        Structured tabular (TSV or CSV) file holding STANDARD DEVIATION metrics values
+        for each individual ROI mask. The tabular file has the following column
+        structure: (sample, roi, metric1, metric2, ..., metricN). Empty unless
+        `roi_sources` includes 'masks' and `roi_outputs` includes 'metrics'.
       structure:
         - meta:
             type: map
             description: Metadata map.
-        - tab_std:
+        - mask_tab_std:
             type: file
-            description: Standard deviation statistics table file.
+            description: Standard deviation statistics table file for the individual ROI masks.
       pattern: "*_desc-std_*.{csv,tsv}"
       ontologies: []
-  - wm_volumes:
+  - mask_volumes:
       type: file
       description: |
-        CSV holding the voxel count and volume (mm3) of each individual ROI mask,
-        in the subject's DWI space — the IIT WM bundles under `use_atlas_iit`, or the
-        masks supplied through `ch_registered_atlas` under `use_registered_atlas`.
-        Empty unless `run_roi_volumes` is enabled.
+        CSV holding the voxel count and volume (mm3) of each individual ROI mask, in the
+        subject's DWI space -- the IIT WM bundles under `use_atlas_iit`, or the masks
+        supplied through `ch_registered_atlas` under `use_registered_atlas`. Empty unless
+        `roi_sources` includes 'masks' and `roi_outputs` includes 'volumes'.
       structure:
         - meta:
             type: map
             description: Metadata map.
-        - wm_volumes:
+        - mask_volumes:
             type: file
-            description: WM bundle volumes table.
+            description: Individual ROI mask volumes table.
       pattern: "*_volumes.csv"
       ontologies:
         - edam: http://edamontology.org/format_3752 # CSV format
-  - gm_stats_json:
+  - labelmap_stats_json:
       type: file
       description: |
-        Per-region GM metrics statistics, as JSON. Empty unless
-        `run_gm_roimetrics` is enabled.
+        Per-region metrics statistics over the labelmap, as JSON. Empty unless
+        `roi_sources` includes 'labelmap' and `roi_outputs` includes 'metrics'.
       structure:
         - meta:
             type: map
             description: Metadata map.
-        - gm_stats_json:
+        - labelmap_stats_json:
             type: file
-            description: JSON statistics file for the GM Desikan regions.
+            description: JSON statistics file for the labelmap regions.
       pattern: "*.json"
       ontologies:
         - edam: http://edamontology.org/format_3464 # JSON format
-  - gm_stats_tab_mean:
+  - labelmap_stats_tab_mean:
       type: file
       description: |
-        Structured tabular (TSV or CSV) file holding MEAN metrics values for
-        each GM Desikan region. Empty unless `run_gm_roimetrics` is enabled.
+        Structured tabular (TSV or CSV) file holding MEAN metrics values for each
+        labelmap region. Empty unless `roi_sources` includes 'labelmap' and
+        `roi_outputs` includes 'metrics'.
       structure:
         - meta:
             type: map
             description: Metadata map.
-        - gm_tab_mean:
+        - labelmap_tab_mean:
             type: file
-            description: Mean statistics table file for the GM Desikan regions.
+            description: Mean statistics table file for the labelmap regions.
       pattern: "*_desc-mean_*.{csv,tsv}"
       ontologies: []
-  - gm_stats_tab_std:
+  - labelmap_stats_tab_std:
       type: file
       description: |
-        Structured tabular (TSV or CSV) file holding STANDARD DEVIATION metrics
-        values for each GM Desikan region. Empty unless `run_gm_roimetrics` is
-        enabled.
+        Structured tabular (TSV or CSV) file holding STANDARD DEVIATION metrics values
+        for each labelmap region. Empty unless `roi_sources` includes 'labelmap' and
+        `roi_outputs` includes 'metrics'.
       structure:
         - meta:
             type: map
             description: Metadata map.
-        - gm_tab_std:
+        - labelmap_tab_std:
             type: file
-            description: Standard deviation statistics table file for the GM Desikan regions.
+            description: Standard deviation statistics table file for the labelmap regions.
       pattern: "*_desc-std_*.{csv,tsv}"
       ontologies: []
-  - gm_volumes:
+  - labelmap_volumes:
       type: file
       description: |
         CSV holding the voxel count and volume (mm3) of each labelmap region, in the
-        subject's DWI space — the GM Desikan regions under `use_atlas_iit`, or the
+        subject's DWI space -- the IIT GM Desikan regions under `use_atlas_iit`, or the
         regions of the labelmap supplied through `ch_registered_atlas` under
-        `use_registered_atlas`. Empty unless `run_roi_volumes` is enabled, and — with
-        the IIT atlas — `run_gm_roimetrics` as well.
+        `use_registered_atlas`. Empty unless `roi_sources` includes 'labelmap' and
+        `roi_outputs` includes 'volumes'.
       structure:
         - meta:
             type: map
             description: Metadata map.
-        - gm_volumes:
+        - labelmap_volumes:
             type: file
-            description: GM Desikan region volumes table.
+            description: Labelmap region volumes table.
       pattern: "*_volumes.csv"
       ontologies:
         - edam: http://edamontology.org/format_3752 # CSV format

--- a/subworkflows/nf-neuro/atlas_roimetrics/tests/main.nf.test
+++ b/subworkflows/nf-neuro/atlas_roimetrics/tests/main.nf.test
@@ -13,6 +13,7 @@ nextflow_workflow {
     tag "subworkflows/atlas_roimetrics"
 
     tag "stats/metricsinroi"
+    tag "stats/roivolumes"
     tag "registration/ants"
     tag "registration/antsapplytransforms"
 
@@ -100,6 +101,99 @@ nextflow_workflow {
             }
         }
 
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out
+                        .findAll{ channel -> !channel.key.isInteger() && channel.value  }
+                        .collectEntries{ channel ->
+                            [(channel.key): ["versions"].contains(channel.key)
+                                ? channel.value
+                                : channel.value.collect{ subject ->
+                                    [ subject[0] ] + subject[1..-1].flatten().collect{ entry -> entry
+                                        ? file(entry).name
+                                        : "" }
+                            } ]
+                        }
+                ).match() }
+            )
+        }
+    }
+
+    test("atlas_roimetrics - IIT atlas - gm roimetrics and volumes") {
+        when {
+            workflow {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+
+                input[0] = ch_split_test_data
+                    .map{ test_data_directory -> [
+                    [ id:'test', single_end:false ], // meta map
+                    file("\${test_data_directory}/b0.nii.gz")
+                    ]}
+                input[1] = ch_split_test_data
+                    .map{ test_data_directory -> [
+                        [ id:'test', single_end:false ], // meta map
+                        [file("\${test_data_directory}/fa.nii.gz"),
+                        file("\${test_data_directory}/ad.nii.gz"),
+                        file("\${test_data_directory}/rd.nii.gz"),
+                        file("\${test_data_directory}/md.nii.gz")]
+                    ]}
+                input[2] = [
+                    use_atlas_iit: true,
+                    use_binary_masks: true,
+                    run_gm_roimetrics: true,
+                    run_roi_volumes: true
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out
+                        .findAll{ channel -> !channel.key.isInteger() && channel.value  }
+                        .collectEntries{ channel ->
+                            [(channel.key): ["versions"].contains(channel.key)
+                                ? channel.value
+                                : channel.value.collect{ subject ->
+                                    [ subject[0] ] + subject[1..-1].flatten().collect{ entry -> entry
+                                        ? file(entry).name
+                                        : "" }
+                            } ]
+                        }
+                ).match() }
+            )
+        }
+    }
+
+    test("atlas_roimetrics - IIT atlas - volumes only") {
+        when {
+            workflow {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+
+                input[0] = ch_split_test_data
+                    .map{ test_data_directory -> [
+                    [ id:'test', single_end:false ], // meta map
+                    file("\${test_data_directory}/b0.nii.gz")
+                    ]}
+                input[1] = ch_split_test_data
+                    .map{ test_data_directory -> [
+                        [ id:'test', single_end:false ], // meta map
+                        [file("\${test_data_directory}/fa.nii.gz")]
+                    ]}
+                input[2] = [
+                    use_atlas_iit: true,
+                    use_binary_masks: true,
+                    run_roi_metrics: false,
+                    run_roi_volumes: true
+                ]
+                """
+            }
+        }
         then {
             assertAll(
                 { assert workflow.success },

--- a/subworkflows/nf-neuro/atlas_roimetrics/tests/main.nf.test
+++ b/subworkflows/nf-neuro/atlas_roimetrics/tests/main.nf.test
@@ -134,7 +134,7 @@ nextflow_workflow {
         }
     }
 
-    test("atlas_roimetrics - IIT atlas - gm roimetrics and volumes") {
+    test("atlas_roimetrics - IIT atlas - both sources, both outputs") {
         when {
             workflow {
                 """
@@ -157,8 +157,8 @@ nextflow_workflow {
                 input[3] = [
                     use_atlas_iit: true,
                     use_binary_masks: true,
-                    run_gm_roimetrics: true,
-                    run_roi_volumes: true
+                    roi_sources: ["masks", "labelmap"],
+                    roi_outputs: ["metrics", "volumes"]
                 ]
                 """
             }
@@ -183,7 +183,7 @@ nextflow_workflow {
         }
     }
 
-    test("atlas_roimetrics - IIT atlas - volumes only") {
+    test("atlas_roimetrics - IIT atlas - masks, volumes only") {
         when {
             workflow {
                 """
@@ -203,8 +203,7 @@ nextflow_workflow {
                 input[3] = [
                     use_atlas_iit: true,
                     use_binary_masks: true,
-                    run_roi_metrics: false,
-                    run_roi_volumes: true
+                    roi_outputs: ["volumes"]
                 ]
                 """
             }
@@ -212,6 +211,61 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
+                { assert snapshot(
+                    workflow.out
+                        .findAll{ channel -> !channel.key.isInteger() && channel.value  }
+                        .collectEntries{ channel ->
+                            [(channel.key): ["versions"].contains(channel.key)
+                                ? channel.value
+                                : channel.value.collect{ subject ->
+                                    [ subject[0] ] + subject[1..-1].flatten().collect{ entry -> entry
+                                        ? file(entry).name
+                                        : "" }
+                            } ]
+                        }
+                ).match() }
+            )
+        }
+    }
+
+    test("atlas_roimetrics - IIT atlas - labelmap only skips the bundle transform") {
+        when {
+            workflow {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+
+                input[0] = ch_split_test_data
+                    .map{ test_data_directory -> [
+                    [ id:'test', single_end:false ], // meta map
+                    file("\${test_data_directory}/b0.nii.gz")
+                    ]}
+                input[1] = ch_split_test_data
+                    .map{ test_data_directory -> [
+                        [ id:'test', single_end:false ], // meta map
+                        [file("\${test_data_directory}/fa.nii.gz")]
+                    ]}
+                input[2] = channel.empty()
+                input[3] = [
+                    use_atlas_iit: true,
+                    roi_sources: ["labelmap"],
+                    roi_outputs: ["metrics", "volumes"]
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert workflow.success },
+                // The mask side is not requested, so neither the bundle warp nor any
+                // mask statistics may run. The registration is still needed for the labelmap.
+                { assert workflow.trace.tasks().every { task ->
+                    !task.name.contains("TRANSFORM_IIT_BUNDLES") &&
+                    !task.name.contains("STATS_MASK_") } },
+                { assert workflow.trace.tasks().any { task ->
+                    task.name.contains("TRANSFORM_IIT_GM_ATLAS") } },
+                { assert workflow.out.mask_stats_tab_mean.size() == 0 },
+                { assert workflow.out.mask_volumes.size() == 0 },
+                { assert workflow.out.labelmap_volumes.size() == 1 },
                 { assert snapshot(
                     workflow.out
                         .findAll{ channel -> !channel.key.isInteger() && channel.value  }
@@ -257,7 +311,7 @@ nextflow_workflow {
                     ]}
                 input[3] = [
                     use_registered_atlas: true,
-                    run_roi_volumes: true
+                    roi_outputs: ["volumes"]
                 ]
                 """
             }
@@ -266,8 +320,8 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert workflow.trace.tasks().every { task ->
-                    !task.name.contains("REGISTER_ATLAS_REF") &&
-                    !task.name.contains("TRANSFORM_ATLAS_BUNDLES") } },
+                    !task.name.contains("REGISTER_IIT_REF") &&
+                    !task.name.contains("TRANSFORM_IIT_BUNDLES") } },
                 { assert snapshot(
                     workflow.out
                         .findAll{ channel -> !channel.key.isInteger() && channel.value  }
@@ -315,8 +369,8 @@ nextflow_workflow {
                     ]}
                 input[3] = [
                     use_registered_atlas: true,
-                    run_roi_metrics: false,
-                    run_roi_volumes: true
+                    roi_sources: ["masks", "labelmap"],
+                    roi_outputs: ["volumes"]
                 ]
                 """
             }
@@ -325,8 +379,8 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 // Both volume outputs must be populated from the single input tuple.
-                { assert workflow.out.wm_volumes.size() == 1 },
-                { assert workflow.out.gm_volumes.size() == 1 },
+                { assert workflow.out.mask_volumes.size() == 1 },
+                { assert workflow.out.labelmap_volumes.size() == 1 },
                 { assert snapshot(
                     workflow.out
                         .findAll{ channel -> !channel.key.isInteger() && channel.value  }
@@ -365,6 +419,32 @@ nextflow_workflow {
                     ]}
                 input[2] = channel.empty()
                 input[3] = [ use_atlas_iit: false ]
+                """
+            }
+        }
+        then {
+            assert workflow.failed
+        }
+    }
+
+    test("atlas_roimetrics - invalid roi_sources value") {
+        when {
+            workflow {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+
+                input[0] = ch_split_test_data
+                    .map{ test_data_directory -> [
+                    [ id:'test', single_end:false ], // meta map
+                    file("\${test_data_directory}/b0.nii.gz")
+                    ]}
+                input[1] = ch_split_test_data
+                    .map{ test_data_directory -> [
+                        [ id:'test', single_end:false ], // meta map
+                        [file("\${test_data_directory}/fa.nii.gz")]
+                    ]}
+                input[2] = channel.empty()
+                input[3] = [ use_atlas_iit: true, roi_sources: ["bundles"] ]
                 """
             }
         }

--- a/subworkflows/nf-neuro/atlas_roimetrics/tests/main.nf.test
+++ b/subworkflows/nf-neuro/atlas_roimetrics/tests/main.nf.test
@@ -32,6 +32,17 @@ nextflow_workflow {
                 """
             }
         }
+        // Separate alias so the channel above keeps emitting a single directory
+        // and the existing tests are unaffected.
+        run("LOAD_TEST_DATA", alias: "LOAD_PLOT") {
+            script "../../load_test_data/main.nf"
+            process {
+                """
+                input[0] = channel.from( [ "plot.zip" ] )
+                input[1] = "test.load-test-data"
+                """
+            }
+        }
     }
 
     test("atlas_roimetrics - IIT atlas - binary") {
@@ -53,7 +64,8 @@ nextflow_workflow {
                         file("\${test_data_directory}/rd.nii.gz"),
                         file("\${test_data_directory}/md.nii.gz")]
                     ]}
-                input[2] = [use_atlas_iit: true, use_binary_masks: true]
+                input[2] = channel.empty()
+                input[3] = [use_atlas_iit: true, use_binary_masks: true]
                 """
             }
         }
@@ -96,7 +108,8 @@ nextflow_workflow {
                         file("\${test_data_directory}/rd.nii.gz"),
                         file("\${test_data_directory}/md.nii.gz")]
                     ]}
-                input[2] = [use_atlas_iit: true] // use_binary_mask: false
+                input[2] = channel.empty()
+                input[3] = [use_atlas_iit: true] // use_binary_mask: false
                 """
             }
         }
@@ -140,7 +153,8 @@ nextflow_workflow {
                         file("\${test_data_directory}/rd.nii.gz"),
                         file("\${test_data_directory}/md.nii.gz")]
                     ]}
-                input[2] = [
+                input[2] = channel.empty()
+                input[3] = [
                     use_atlas_iit: true,
                     use_binary_masks: true,
                     run_gm_roimetrics: true,
@@ -185,7 +199,8 @@ nextflow_workflow {
                         [ id:'test', single_end:false ], // meta map
                         [file("\${test_data_directory}/fa.nii.gz")]
                     ]}
-                input[2] = [
+                input[2] = channel.empty()
+                input[3] = [
                     use_atlas_iit: true,
                     use_binary_masks: true,
                     run_roi_metrics: false,
@@ -197,6 +212,121 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
+                { assert snapshot(
+                    workflow.out
+                        .findAll{ channel -> !channel.key.isInteger() && channel.value  }
+                        .collectEntries{ channel ->
+                            [(channel.key): ["versions"].contains(channel.key)
+                                ? channel.value
+                                : channel.value.collect{ subject ->
+                                    [ subject[0] ] + subject[1..-1].flatten().collect{ entry -> entry
+                                        ? file(entry).name
+                                        : "" }
+                            } ]
+                        }
+                ).match() }
+            )
+        }
+    }
+
+    test("atlas_roimetrics - pre-registered atlas - no download or registration") {
+        when {
+            workflow {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+
+                input[0] = ch_split_test_data
+                    .map{ test_data_directory -> [
+                    [ id:'test', single_end:false ], // meta map
+                    file("\${test_data_directory}/b0.nii.gz")
+                    ]}
+                input[1] = ch_split_test_data
+                    .map{ test_data_directory -> [
+                        [ id:'test', single_end:false ], // meta map
+                        [file("\${test_data_directory}/fa.nii.gz"),
+                        file("\${test_data_directory}/md.nii.gz")]
+                    ]}
+                // ROI masks already in the subject's space, no labelmap supplied
+                input[2] = ch_split_test_data
+                    .map{ test_data_directory -> [
+                        [ id:'test', single_end:false ], // meta map
+                        [file("\${test_data_directory}/fa_thr.nii.gz"),
+                        file("\${test_data_directory}/seed.nii.gz")],
+                        [],
+                        []
+                    ]}
+                input[3] = [
+                    use_registered_atlas: true,
+                    run_roi_volumes: true
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.trace.tasks().every { task ->
+                    !task.name.contains("REGISTER_ATLAS_REF") &&
+                    !task.name.contains("TRANSFORM_ATLAS_BUNDLES") } },
+                { assert snapshot(
+                    workflow.out
+                        .findAll{ channel -> !channel.key.isInteger() && channel.value  }
+                        .collectEntries{ channel ->
+                            [(channel.key): ["versions"].contains(channel.key)
+                                ? channel.value
+                                : channel.value.collect{ subject ->
+                                    [ subject[0] ] + subject[1..-1].flatten().collect{ entry -> entry
+                                        ? file(entry).name
+                                        : "" }
+                            } ]
+                        }
+                ).match() }
+            )
+        }
+    }
+
+    test("atlas_roimetrics - pre-registered atlas - masks and labelmap together") {
+        when {
+            workflow {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+                ch_plot_test_data  = LOAD_PLOT.out.test_data_directory
+
+                input[0] = ch_split_test_data
+                    .map{ test_data_directory -> [
+                    [ id:'test', single_end:false ], // meta map
+                    file("\${test_data_directory}/b0.nii.gz")
+                    ]}
+                input[1] = ch_split_test_data
+                    .map{ test_data_directory -> [
+                        [ id:'test', single_end:false ], // meta map
+                        [file("\${test_data_directory}/fa.nii.gz")]
+                    ]}
+                // Both representations in the same entry: the tuple is read twice
+                // internally, once for the masks and once for the labelmap.
+                input[2] = ch_split_test_data
+                    .combine(ch_plot_test_data)
+                    .map{ processing_dir, plot_dir -> [
+                        [ id:'test', single_end:false ], // meta map
+                        [file("\${processing_dir}/fa_thr.nii.gz"),
+                        file("\${processing_dir}/seed.nii.gz")],
+                        file("\${plot_dir}/atlas_brainnetome.nii.gz"),
+                        file("\${plot_dir}/atlas_brainnetome.json")
+                    ]}
+                input[3] = [
+                    use_registered_atlas: true,
+                    run_roi_metrics: false,
+                    run_roi_volumes: true
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert workflow.success },
+                // Both volume outputs must be populated from the single input tuple.
+                { assert workflow.out.wm_volumes.size() == 1 },
+                { assert workflow.out.gm_volumes.size() == 1 },
                 { assert snapshot(
                     workflow.out
                         .findAll{ channel -> !channel.key.isInteger() && channel.value  }
@@ -233,7 +363,8 @@ nextflow_workflow {
                         file("\${test_data_directory}/rd.nii.gz"),
                         file("\${test_data_directory}/md.nii.gz")]
                     ]}
-                input[2] = [ use_atlas_iit: false ]
+                input[2] = channel.empty()
+                input[3] = [ use_atlas_iit: false ]
                 """
             }
         }

--- a/subworkflows/nf-neuro/atlas_roimetrics/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/atlas_roimetrics/tests/main.nf.test.snap
@@ -2,7 +2,7 @@
     "atlas_roimetrics - IIT atlas - weighted": {
         "content": [
             {
-                "stats_json": [
+                "mask_stats_json": [
                     [
                         {
                             "id": "test",
@@ -11,7 +11,7 @@
                         "test_stats.json"
                     ]
                 ],
-                "stats_tab_mean": [
+                "mask_stats_tab_mean": [
                     [
                         {
                             "id": "test",
@@ -20,7 +20,7 @@
                         "test_desc-mean_stats.tsv"
                     ]
                 ],
-                "stats_tab_std": [
+                "mask_stats_tab_std": [
                     [
                         {
                             "id": "test",
@@ -30,53 +30,115 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,10c3c16a89dcab69d4b036e0569aa826",
-                    "versions.yml:md5,3866571f819aa78d2b2d019c8df1a88b",
-                    "versions.yml:md5,4b945b03a70d84217c7916069100e024"
+                    "versions.yml:md5,00d3a53c47c3bf6caf683f6659218a64",
+                    "versions.yml:md5,4ae7d5bbb358f56c945115cb4e617991",
+                    "versions.yml:md5,59809bce7ccc6bf1272bbc9af9d8e9ac"
                 ]
             }
         ],
-        "timestamp": "2026-06-02T20:47:31.389116538",
+        "timestamp": "2026-08-22T18:08:48.831839897",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
+    "atlas_roimetrics - IIT atlas - both sources, both outputs": {
+        "content": [
+            {
+                "labelmap_stats_json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_stats.json"
+                    ]
+                ],
+                "labelmap_stats_tab_mean": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_desc-mean_stats.tsv"
+                    ]
+                ],
+                "labelmap_stats_tab_std": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_desc-std_stats.tsv"
+                    ]
+                ],
+                "labelmap_volumes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_volumes.csv"
+                    ]
+                ],
+                "mask_stats_json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_stats.json"
+                    ]
+                ],
+                "mask_stats_tab_mean": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_desc-mean_stats.tsv"
+                    ]
+                ],
+                "mask_stats_tab_std": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_desc-std_stats.tsv"
+                    ]
+                ],
+                "mask_volumes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_volumes.csv"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,00d3a53c47c3bf6caf683f6659218a64",
+                    "versions.yml:md5,09bc025600bffe8e8d4ee5d6a4746d90",
+                    "versions.yml:md5,4ae7d5bbb358f56c945115cb4e617991",
+                    "versions.yml:md5,59809bce7ccc6bf1272bbc9af9d8e9ac",
+                    "versions.yml:md5,5aab53e71beaecf093af3c8c77d28e9e",
+                    "versions.yml:md5,ab1f5e2c45ba3e9d1810f6e22a425d5f",
+                    "versions.yml:md5,b42b47a62121377427d444d9f955daea",
+                    "versions.yml:md5,df48bea11ad4fde0e42c6745a2daf11a"
+                ]
+            }
+        ],
+        "timestamp": "2026-08-22T18:10:20.466566188",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
         }
     },
     "atlas_roimetrics - pre-registered atlas - no download or registration": {
         "content": [
             {
-                "stats_json": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_stats.json"
-                    ]
-                ],
-                "stats_tab_mean": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_desc-mean_stats.tsv"
-                    ]
-                ],
-                "stats_tab_std": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_desc-std_stats.tsv"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,3866571f819aa78d2b2d019c8df1a88b",
-                    "versions.yml:md5,b0a567e19a5f8c519a85b6d279843b70"
-                ],
-                "wm_volumes": [
+                "mask_volumes": [
                     [
                         {
                             "id": "test",
@@ -84,25 +146,49 @@
                         },
                         "test_volumes.csv"
                     ]
+                ],
+                "versions": [
+                    "versions.yml:md5,09bc025600bffe8e8d4ee5d6a4746d90"
                 ]
             }
         ],
-        "timestamp": "2026-08-22T17:13:17.811559166",
+        "timestamp": "2026-08-22T18:12:19.628219669",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"
         }
     },
-    "atlas_roimetrics - IIT atlas - volumes only": {
+    "atlas_roimetrics - IIT atlas - labelmap only skips the bundle transform": {
         "content": [
             {
-                "versions": [
-                    "versions.yml:md5,10c3c16a89dcab69d4b036e0569aa826",
-                    "versions.yml:md5,4b945b03a70d84217c7916069100e024",
-                    "versions.yml:md5,5aab53e71beaecf093af3c8c77d28e9e",
-                    "versions.yml:md5,b0a567e19a5f8c519a85b6d279843b70"
+                "labelmap_stats_json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_stats.json"
+                    ]
                 ],
-                "wm_volumes": [
+                "labelmap_stats_tab_mean": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_desc-mean_stats.tsv"
+                    ]
+                ],
+                "labelmap_stats_tab_std": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_desc-std_stats.tsv"
+                    ]
+                ],
+                "labelmap_volumes": [
                     [
                         {
                             "id": "test",
@@ -110,103 +196,42 @@
                         },
                         "test_volumes.csv"
                     ]
+                ],
+                "versions": [
+                    "versions.yml:md5,4ae7d5bbb358f56c945115cb4e617991",
+                    "versions.yml:md5,ab1f5e2c45ba3e9d1810f6e22a425d5f",
+                    "versions.yml:md5,b42b47a62121377427d444d9f955daea",
+                    "versions.yml:md5,df48bea11ad4fde0e42c6745a2daf11a"
                 ]
             }
         ],
-        "timestamp": "2026-08-22T15:31:46.218779404",
+        "timestamp": "2026-08-22T18:12:11.110968442",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"
         }
     },
-    "atlas_roimetrics - IIT atlas - gm roimetrics and volumes": {
+    "atlas_roimetrics - IIT atlas - masks, volumes only": {
         "content": [
             {
-                "gm_stats_json": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_stats.json"
-                    ]
-                ],
-                "gm_stats_tab_mean": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_desc-mean_stats.tsv"
-                    ]
-                ],
-                "gm_stats_tab_std": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_desc-std_stats.tsv"
-                    ]
-                ],
-                "gm_volumes": [
+                "mask_volumes": [
                     [
                         {
                             "id": "test",
                             "single_end": false
                         },
                         "test_volumes.csv"
-                    ]
-                ],
-                "stats_json": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_stats.json"
-                    ]
-                ],
-                "stats_tab_mean": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_desc-mean_stats.tsv"
-                    ]
-                ],
-                "stats_tab_std": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_desc-std_stats.tsv"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,10c3c16a89dcab69d4b036e0569aa826",
-                    "versions.yml:md5,3866571f819aa78d2b2d019c8df1a88b",
-                    "versions.yml:md5,4b945b03a70d84217c7916069100e024",
-                    "versions.yml:md5,5aab53e71beaecf093af3c8c77d28e9e",
-                    "versions.yml:md5,76e845b49b32f6cc7dda4948025fbafd",
-                    "versions.yml:md5,a319f96104afdbcac16ab317e7de4c7f",
-                    "versions.yml:md5,b0a567e19a5f8c519a85b6d279843b70",
-                    "versions.yml:md5,ddc926908b33b73b0269fedbc1fe5eb2"
-                ],
-                "wm_volumes": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_volumes.csv"
-                    ]
+                    "versions.yml:md5,09bc025600bffe8e8d4ee5d6a4746d90",
+                    "versions.yml:md5,4ae7d5bbb358f56c945115cb4e617991",
+                    "versions.yml:md5,59809bce7ccc6bf1272bbc9af9d8e9ac",
+                    "versions.yml:md5,5aab53e71beaecf093af3c8c77d28e9e"
                 ]
             }
         ],
-        "timestamp": "2026-08-22T15:30:51.541691214",
+        "timestamp": "2026-08-22T18:11:44.860735397",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"
@@ -215,7 +240,16 @@
     "atlas_roimetrics - pre-registered atlas - masks and labelmap together": {
         "content": [
             {
-                "gm_volumes": [
+                "labelmap_volumes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_volumes.csv"
+                    ]
+                ],
+                "mask_volumes": [
                     [
                         {
                             "id": "test",
@@ -225,21 +259,12 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,76e845b49b32f6cc7dda4948025fbafd",
-                    "versions.yml:md5,b0a567e19a5f8c519a85b6d279843b70"
-                ],
-                "wm_volumes": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_volumes.csv"
-                    ]
+                    "versions.yml:md5,09bc025600bffe8e8d4ee5d6a4746d90",
+                    "versions.yml:md5,df48bea11ad4fde0e42c6745a2daf11a"
                 ]
             }
         ],
-        "timestamp": "2026-08-22T17:21:18.865394355",
+        "timestamp": "2026-08-22T18:12:27.691703023",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"
@@ -248,7 +273,7 @@
     "atlas_roimetrics - IIT atlas - binary": {
         "content": [
             {
-                "stats_json": [
+                "mask_stats_json": [
                     [
                         {
                             "id": "test",
@@ -257,7 +282,7 @@
                         "test_stats.json"
                     ]
                 ],
-                "stats_tab_mean": [
+                "mask_stats_tab_mean": [
                     [
                         {
                             "id": "test",
@@ -266,7 +291,7 @@
                         "test_desc-mean_stats.tsv"
                     ]
                 ],
-                "stats_tab_std": [
+                "mask_stats_tab_std": [
                     [
                         {
                             "id": "test",
@@ -276,17 +301,17 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,10c3c16a89dcab69d4b036e0569aa826",
-                    "versions.yml:md5,3866571f819aa78d2b2d019c8df1a88b",
-                    "versions.yml:md5,4b945b03a70d84217c7916069100e024",
+                    "versions.yml:md5,00d3a53c47c3bf6caf683f6659218a64",
+                    "versions.yml:md5,4ae7d5bbb358f56c945115cb4e617991",
+                    "versions.yml:md5,59809bce7ccc6bf1272bbc9af9d8e9ac",
                     "versions.yml:md5,5aab53e71beaecf093af3c8c77d28e9e"
                 ]
             }
         ],
-        "timestamp": "2026-06-02T20:47:03.44657253",
+        "timestamp": "2026-08-22T18:08:23.465449305",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
         }
     }
 }

--- a/subworkflows/nf-neuro/atlas_roimetrics/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/atlas_roimetrics/tests/main.nf.test.snap
@@ -42,6 +42,57 @@
             "nextflow": "25.10.2"
         }
     },
+    "atlas_roimetrics - pre-registered atlas - no download or registration": {
+        "content": [
+            {
+                "stats_json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_stats.json"
+                    ]
+                ],
+                "stats_tab_mean": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_desc-mean_stats.tsv"
+                    ]
+                ],
+                "stats_tab_std": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_desc-std_stats.tsv"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,3866571f819aa78d2b2d019c8df1a88b",
+                    "versions.yml:md5,b0a567e19a5f8c519a85b6d279843b70"
+                ],
+                "wm_volumes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_volumes.csv"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-22T17:13:17.811559166",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
     "atlas_roimetrics - IIT atlas - volumes only": {
         "content": [
             {
@@ -156,6 +207,39 @@
             }
         ],
         "timestamp": "2026-08-22T15:30:51.541691214",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
+    "atlas_roimetrics - pre-registered atlas - masks and labelmap together": {
+        "content": [
+            {
+                "gm_volumes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_volumes.csv"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,76e845b49b32f6cc7dda4948025fbafd",
+                    "versions.yml:md5,b0a567e19a5f8c519a85b6d279843b70"
+                ],
+                "wm_volumes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_volumes.csv"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-22T17:21:18.865394355",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/subworkflows/nf-neuro/atlas_roimetrics/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/atlas_roimetrics/tests/main.nf.test.snap
@@ -36,11 +36,130 @@
                 ]
             }
         ],
+        "timestamp": "2026-06-02T20:47:31.389116538",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-06-02T20:47:31.389116538"
+        }
+    },
+    "atlas_roimetrics - IIT atlas - volumes only": {
+        "content": [
+            {
+                "versions": [
+                    "versions.yml:md5,10c3c16a89dcab69d4b036e0569aa826",
+                    "versions.yml:md5,4b945b03a70d84217c7916069100e024",
+                    "versions.yml:md5,5aab53e71beaecf093af3c8c77d28e9e",
+                    "versions.yml:md5,b0a567e19a5f8c519a85b6d279843b70"
+                ],
+                "wm_volumes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_volumes.csv"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-22T15:31:46.218779404",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
+    "atlas_roimetrics - IIT atlas - gm roimetrics and volumes": {
+        "content": [
+            {
+                "gm_stats_json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_stats.json"
+                    ]
+                ],
+                "gm_stats_tab_mean": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_desc-mean_stats.tsv"
+                    ]
+                ],
+                "gm_stats_tab_std": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_desc-std_stats.tsv"
+                    ]
+                ],
+                "gm_volumes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_volumes.csv"
+                    ]
+                ],
+                "stats_json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_stats.json"
+                    ]
+                ],
+                "stats_tab_mean": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_desc-mean_stats.tsv"
+                    ]
+                ],
+                "stats_tab_std": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_desc-std_stats.tsv"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,10c3c16a89dcab69d4b036e0569aa826",
+                    "versions.yml:md5,3866571f819aa78d2b2d019c8df1a88b",
+                    "versions.yml:md5,4b945b03a70d84217c7916069100e024",
+                    "versions.yml:md5,5aab53e71beaecf093af3c8c77d28e9e",
+                    "versions.yml:md5,76e845b49b32f6cc7dda4948025fbafd",
+                    "versions.yml:md5,a319f96104afdbcac16ab317e7de4c7f",
+                    "versions.yml:md5,b0a567e19a5f8c519a85b6d279843b70",
+                    "versions.yml:md5,ddc926908b33b73b0269fedbc1fe5eb2"
+                ],
+                "wm_volumes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_volumes.csv"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-22T15:30:51.541691214",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
     },
     "atlas_roimetrics - IIT atlas - binary": {
         "content": [
@@ -80,10 +199,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-06-02T20:47:03.44657253",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-06-02T20:47:03.44657253"
+        }
     }
 }


### PR DESCRIPTION
## Describe your changes
New module stats/roivolumes that computes voxel counts and volumes (mm³) for ROI regions. Supports two modes: WM (list of binary/TDI masks, one per bundle) and GM (single label atlas with JSON Look-Up Table (LUT)). Uses nibabel and numpy directly — no scilpy CLI dependency.

## List test packages used by your module
tractometry.zip (WM binary masks test)
plot.zip (GM label atlas test from Brainnetome atlas)

## Checklist before requesting a review

- Create the tool:
  - [X] Edit `./modules/nf-neuro/<category>/<tool>/main.nf`
  - [X] Edit `./modules/nf-neuro/<category>/<tool>/meta.yml`
  - [X] Edit `./modules/nf-neuro/<category>/<tool>/environment.yml`
- Generate the tests:
  - [X] Edit `./modules/nf-neuro/<category>/<tool>/tests/main.nf.test`
  - [X] Run the tests to generate the `main.nf.test.snap` snapshots
- Ensure the syntax is correct :
  - [X] Run `prettier` and `editorconfig-checker` to fix common syntax issues
  - [ ] Run `nf-core modules lint` and fix all errors [1]
  - [X] Ensure your variables have good, clear names

[1] Note: main_nf_ext_key and main_nf_meta_key failures remain. To my understanding, these are nf-core v4.0.3-only checks not enforced by the nf-neuro CI (which uses ≤3.5.2). The same patterns (ext.first_suffix, ext.use_label, ext.key_substrs_to_remove, meta.session, meta.run) exist in the already-merged stats/metricsinroi module. Please advise if a repo-wide fix is expected

Thank you for your time for reviewing this contribution!